### PR TITLE
Split off init tasks

### DIFF
--- a/pkg/neutronovsagent/configmap.go
+++ b/pkg/neutronovsagent/configmap.go
@@ -12,7 +12,28 @@ type neutronOvsAgentConfigOptions struct {
         Debug string
 }
 
-// custom nova config map
+// neutron-ovsagent-init config map
+func InitConfigMap(cr *neutronv1.NeutronOvsAgent, cmName string) *corev1.ConfigMap {
+
+        cm := &corev1.ConfigMap{
+                TypeMeta: metav1.TypeMeta{
+                        APIVersion: "v1",
+                        Kind:       "ConfigMap",
+                },
+                ObjectMeta: metav1.ObjectMeta{
+                        Name:      cmName,
+                        Namespace: cr.Namespace,
+                },
+                Data: map[string]string{
+                        "common.sh":                  util.ExecuteTemplateFile("common.sh", nil),
+                        "openvswitch_agent_init.sh":  util.ExecuteTemplateFile("openvswitch_agent_init.sh", nil),
+                },
+        }
+
+        return cm
+}
+
+// neutron-ovsagent config map
 func ConfigMap(cr *neutronv1.NeutronOvsAgent, cmName string) *corev1.ConfigMap {
         opts := neutronOvsAgentConfigOptions{cr.Spec.RabbitTransportUrl,
                                              cr.Spec.Debug}
@@ -27,8 +48,8 @@ func ConfigMap(cr *neutronv1.NeutronOvsAgent, cmName string) *corev1.ConfigMap {
                         Namespace: cr.Namespace,
                 },
                 Data: map[string]string{
-                        "neutron.conf":            util.ExecuteTemplateFile("neutron.conf", &opts),
-                        "openvswitch_agent.ini":   util.ExecuteTemplateFile("openvswitch_agent.ini", nil),
+                        "neutron.conf":           util.ExecuteTemplateFile("neutron.conf", &opts),
+                        "openvswitch_agent.ini":  util.ExecuteTemplateFile("openvswitch_agent.ini", nil),
                 },
         }
 

--- a/templates/common.sh
+++ b/templates/common.sh
@@ -1,0 +1,28 @@
+#!/bin//bash
+#
+# Copyright 2018 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+set -e
+
+function get_ip_address_from_network {
+  local network=$1
+  # for now we expect that controller-0 is always there and has this name
+  local controller_ip=$(getent hosts controller-0.${network} | awk '{print $1}')
+  local ip=$(ip route get ${controller_ip} | awk '{print $5}')
+  if [ -z "${ip}" ] ; then
+    exit 
+  fi
+  echo ${ip}
+}

--- a/templates/openvswitch_agent_init.sh
+++ b/templates/openvswitch_agent_init.sh
@@ -1,0 +1,41 @@
+#!/bin//bash
+#
+# Copyright 2018 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+set -ex
+
+# expect that the common.sh is in the same dir as the calling script
+SCRIPTPATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+. ${SCRIPTPATH}/common.sh --source-only
+
+CONFIG_VOLUME=$1
+if [ -z "${CONFIG_VOLUME}" ] ; then
+  echo "No config volume specified!"
+  exit 1
+fi
+
+
+# copy default configs to the tmp config volume
+cp -a /etc/neutron/* ${CONFIG_VOLUME}/
+
+LOCAL_IP=$(get_ip_address_from_network "tenant")
+crudini --set ${CONFIG_VOLUME}/plugins/ml2/openvswitch_agent.ini ovs local_ip $LOCAL_IP
+
+# create required bridges from bridge_mappings setting in openvswitch_agent.ini
+IFS=',' read -r -a bridge_mappings <<< $(crudini --get ${CONFIG_VOLUME}/plugins/ml2/openvswitch_agent.ini ovs bridge_mappings)
+for br in "${bridge_mappings[@]}"; do
+  bridge=$(echo $br | awk -F ':' '{print $2}';)
+  ovs-vsctl --may-exist add-br ${bridge} -- set Bridge ${bridge} fail-mode=secure
+done


### PR DESCRIPTION
Introduced templates/common.sh and templates/openvswitch_agent_init.sh
to run the container init tasks and run openvswitch_agent_init.sh with
the volume which stores the rendered configuration as parameter. The
init scripts are stored in its own configmap which allows us to mount
then with a different mask.

common.sh is intended to be a common functions lib for all the init
tasks for the neutron-operator.