### PR TITLE
Rework Dockerfile and add Dockerfile.rhel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,50 +1,64 @@
-# Build the manager binary
-FROM golang:1.13 as builder
+# golang-builder is used in OSBS build
+ARG GOLANG_BUILDER=golang:1.13
+ARG OPERATOR_BASE_IMAGE=registry.access.redhat.com/ubi7/ubi-minimal:latest
 
-WORKDIR /workspace
-# Copy the Go Modules manifests
-COPY go.mod go.mod
-COPY go.sum go.sum
-# cache deps before building and copying source so that we don't need to re-download as much
-# and so that source changes don't invalidate our downloaded layer
-RUN go mod download
+FROM ${GOLANG_BUILDER} AS builder
 
-# Copy the go source
-COPY main.go main.go
-COPY api/ api/
-COPY controllers/ controllers/
-COPY pkg/ pkg/
-COPY templates/ templates/
-COPY tools/ tools/
+ARG REMOTE_SOURCE=.
+ARG REMOTE_SOURCE_DIR=neutron-operator
+ARG REMOTE_SOURCE_SUBDIR=.
+ARG DEST_ROOT=/dest-root
+ARG GO_BUILD_EXTRA_ARGS="-v"
+
+COPY $REMOTE_SOURCE $REMOTE_SOURCE_DIR
+WORKDIR ${REMOTE_SOURCE_DIR}/${REMOTE_SOURCE_SUBDIR}
+
+RUN mkdir -p ${DEST_ROOT}/usr/local/bin/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o csv-generator tools/csv-generator.go
+RUN CGO_ENABLED=0 GO111MODULE=on go build ${GO_BUILD_EXTRA_ARGS} -a -o ${DEST_ROOT}/usr/local/bin/manager main.go
+RUN CGO_ENABLED=0 GO111MODULE=on go build ${GO_BUILD_EXTRA_ARGS} -a -o ${DEST_ROOT}/usr/local/bin/csv-generator tools/csv-generator.go
 
-FROM registry.access.redhat.com/ubi7/ubi-minimal:latest
+RUN cp tools/user_setup ${DEST_ROOT}/usr/local/bin/
+RUN cp -r templates ${DEST_ROOT}/templates
+
+# prep the bundle
+RUN mkdir -p ${DEST_ROOT}/bundle
+RUN cp config/crd/bases/neutron.openstack.org_neutronsriovagents.yaml ${DEST_ROOT}/bundle/neutron.openstack.org_neutronsriovagents.yaml
+RUN cp config/crd/bases/neutron.openstack.org_ovncontrollers.yaml ${DEST_ROOT}/bundle/neutron.openstack.org_ovncontrollers.yaml
+RUN cp config/crd/bases/neutron.openstack.org_ovsnodeosp.yaml ${DEST_ROOT}/bundle/neutron.openstack.org_ovsnodeosp.yaml
+
+# strip top 2 lines (this resolves parsing in opm which handles this badly)
+RUN sed -i -e 1,2d ${DEST_ROOT}/bundle/*
+
+FROM ${OPERATOR_BASE_IMAGE}
+ARG DEST_ROOT=/dest-root
+
+LABEL   com.redhat.component="neutron-operator-container" \
+        name="neutron-operator" \
+        version="1.0" \
+        summary="Neutron Operator" \
+        io.k8s.name="neutron-operator" \
+        io.k8s.description="This image includes the neutron-operator"
+
 ENV USER_UID=1001 \
     OPERATOR_TEMPLATES=/usr/share/neutron-operator/templates/ \
     OPERATOR_BUNDLE=/usr/share/neutron-operator/bundle/
 
+# install operator binary
+COPY --from=builder ${DEST_ROOT}/usr/local/bin/* /usr/local/bin/
+
 # install our templates
 RUN  mkdir -p ${OPERATOR_TEMPLATES}
-COPY templates ${OPERATOR_TEMPLATES}
+COPY --from=builder ${DEST_ROOT}/templates ${OPERATOR_TEMPLATES}
 
 # install CRDs and required roles, services, etc
 RUN  mkdir -p ${OPERATOR_BUNDLE}
-COPY config/crd/bases/neutron.openstack.org_neutronsriovagents.yaml ${OPERATOR_BUNDLE}/neutron.openstack.org_neutronsriovagents.yaml
-COPY config/crd/bases/neutron.openstack.org_ovncontrollers.yaml ${OPERATOR_BUNDLE}/neutron.openstack.org_ovncontrollers.yaml
-COPY config/crd/bases/neutron.openstack.org_ovsnodeosp.yaml ${OPERATOR_BUNDLE}/neutron.openstack.org_ovsnodeosp.yaml
-
-# strip top 2 lines (this resolves parsing in opm which handles this badly)
-RUN sed -i -e 1,2d ${OPERATOR_BUNDLE}/*
+COPY --from=builder ${DEST_ROOT}/bundle/* ${OPERATOR_BUNDLE}
 
 WORKDIR /
-COPY --from=builder /workspace/manager /usr/local/bin/manager
-COPY --from=builder /workspace/csv-generator /usr/local/bin/csv-generator
 
 # user setup
-COPY tools/user_setup /usr/local/bin/user_setup
 RUN  /usr/local/bin/user_setup
 USER ${USER_UID}
 

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,48 +1,66 @@
-FROM openshift/golang-builder:1.13 AS build-env
+# golang-builder is used in OSBS build
+ARG GOLANG_BUILDER=openshift/golang-builder:1.13
+ARG OPERATOR_BASE_IMAGE=registry.redhat.io/ubi8/ubi-minimal:latest
+
+FROM ${GOLANG_BUILDER} AS builder
+
 # Intended to build in OSBS using cachito external sources bundle
+ARG REMOTE_SOURCE=.
+ARG REMOTE_SOURCE_DIR
+ARG REMOTE_SOURCE_SUBDIR=app
+ARG DEST_ROOT=/dest-root
+ARG GO_BUILD_EXTRA_ARGS="-mod readonly -v "
 
 COPY $REMOTE_SOURCE $REMOTE_SOURCE_DIR
-WORKDIR $REMOTE_SOURCE_DIR/app
-RUN mkdir -p /dest-root/usr/local/bin
+WORKDIR ${REMOTE_SOURCE_DIR}/${REMOTE_SOURCE_SUBDIR}
 
-RUN go build -mod readonly -v -a -ldflags '-extldflags "-static"' -o /dest-root/csv-generator tools/csv-generator.go
-RUN go build -mod readonly -v -a -ldflags '-extldflags "-static"' -o /dest-root/operator cmd/manager/main.go
+RUN mkdir -p ${DEST_ROOT}/usr/local/bin/
 
-RUN cp -r build/bin/* /dest-root/usr/local/bin
-RUN cp -r templates /dest-root/templates
-RUN cp -r deploy/crds /dest-root/crds
+# Build
+RUN CGO_ENABLED=0 GO111MODULE=on go build ${GO_BUILD_EXTRA_ARGS} -a -o ${DEST_ROOT}/usr/local/bin/manager main.go
+RUN CGO_ENABLED=0 GO111MODULE=on go build ${GO_BUILD_EXTRA_ARGS} -a -o ${DEST_ROOT}/usr/local/bin/csv-generator tools/csv-generator.go
 
-FROM ubi8-minimal:8.1-released
+RUN cp tools/user_setup ${DEST_ROOT}/usr/local/bin/
+RUN cp -r templates ${DEST_ROOT}/templates
+
+# prep the bundle
+RUN mkdir -p ${DEST_ROOT}/bundle
+RUN cp config/crd/bases/neutron.openstack.org_neutronsriovagents.yaml ${DEST_ROOT}/bundle/neutron.openstack.org_neutronsriovagents.yaml
+RUN cp config/crd/bases/neutron.openstack.org_ovncontrollers.yaml ${DEST_ROOT}/bundle/neutron.openstack.org_ovncontrollers.yaml
+RUN cp config/crd/bases/neutron.openstack.org_ovsnodeosp.yaml ${DEST_ROOT}/bundle/neutron.openstack.org_ovsnodeosp.yaml
+
+# strip top 2 lines (this resolves parsing in opm which handles this badly)
+RUN sed -i -e 1,2d ${DEST_ROOT}/bundle/*
+
+FROM ${OPERATOR_BASE_IMAGE}
+ARG DEST_ROOT=/dest-root
 
 LABEL   com.redhat.component="neutron-operator-container" \
         name="neutron-operator" \
         version="1.0" \
-        architecture="x86_64" \
         summary="Neutron Operator" \
         io.k8s.name="neutron-operator" \
         io.k8s.description="This image includes the neutron-operator"
 
-ENV OPERATOR=/usr/local/bin/neutron-operator \
-    USER_UID=1001 \
-    USER_NAME=neutron-operator \
+ENV USER_UID=1001 \
     OPERATOR_TEMPLATES=/usr/share/neutron-operator/templates/ \
     OPERATOR_BUNDLE=/usr/share/neutron-operator/bundle/
 
 # install operator binary
-COPY --from=build-env /dest-root/operator ${OPERATOR}
-COPY --from=build-env /dest-root/csv-generator /usr/local/bin/csv-generator
-
-COPY --from=build-env /dest-root/usr/local/bin/* /usr/local/bin
-RUN  /usr/local/bin/user_setup
+COPY --from=builder ${DEST_ROOT}/usr/local/bin/* /usr/local/bin/
 
 # install our templates
 RUN  mkdir -p ${OPERATOR_TEMPLATES}
-COPY --from=build-env /dest-root/templates ${OPERATOR_TEMPLATES}
+COPY --from=builder ${DEST_ROOT}/templates ${OPERATOR_TEMPLATES}
 
 # install CRDs and required roles, services, etc
 RUN  mkdir -p ${OPERATOR_BUNDLE}
-COPY --from=build-env /dest-root/crds/*crd.yaml ${OPERATOR_BUNDLE}
+COPY --from=builder ${DEST_ROOT}/bundle/* ${OPERATOR_BUNDLE}
 
-ENTRYPOINT ["/usr/local/bin/entrypoint"]
+WORKDIR /
 
+# user setup
+RUN  /usr/local/bin/user_setup
 USER ${USER_UID}
+
+ENTRYPOINT ["/usr/local/bin/manager"]


### PR DESCRIPTION
- use ARG's for variants between the 2 files
- Dockerfile.rhel is intended to build in
  OSBS using cachito external sources bundle
- dropped CGO_ARCH and target from building
- copy all of the source in and then setup
  for copying into final image
- go builds should be statically linked now
- crds are copied into a bundle folder first
  and then copied as a whole into final image
- Dockerfile should continue to work as
  expected for local builds
- Dockerfile.rhel should work for building downstream