### PR TITLE
Fix defaulting PasswordSelectors

### DIFF
--- a/api/bases/neutron.openstack.org_neutronapis.yaml
+++ b/api/bases/neutron.openstack.org_neutronapis.yaml
@@ -102,23 +102,27 @@ spec:
                   SBConnection string
                 type: string
               passwordSelectors:
+                default:
+                  database: NeutronDatabasePassword
+                  novaservice: NovaPassword
+                  service: NeutronPassword
                 description: PasswordSelectors - Selectors to identify the DB and
-                  AdminUser password from the Secret
+                  ServiceUser and NoveService User password from the Secret
                 properties:
-                  admin:
-                    default: NeutronPassword
-                    description: Database - Selector to get the neutron service password
-                      from the Secret
-                    type: string
                   database:
                     default: NeutronDatabasePassword
                     description: 'Database - Selector to get the neutron database
                       user password from the Secret TODO: not used, need change in
                       mariadb-operator'
                     type: string
-                  novaadmin:
+                  novaservice:
                     default: NovaPassword
                     description: Database - Selector to get the nova service password
+                      from the Secret
+                    type: string
+                  service:
+                    default: NeutronPassword
+                    description: Database - Selector to get the neutron service password
                       from the Secret
                     type: string
                 type: object

--- a/api/v1beta1/neutronapi_types.go
+++ b/api/v1beta1/neutronapi_types.go
@@ -75,7 +75,8 @@ type NeutronAPISpec struct {
 	Secret string `json:"secret,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// PasswordSelectors - Selectors to identify the DB and AdminUser password from the Secret
+	// +kubebuilder:default={database: NeutronDatabasePassword, service: NeutronPassword, novaservice: NovaPassword}
+	// PasswordSelectors - Selectors to identify the DB and ServiceUser and NoveService User password from the Secret
 	PasswordSelectors PasswordSelector `json:"passwordSelectors,omitempty"`
 
 	// +kubebuilder:validation:Optional
@@ -125,11 +126,11 @@ type PasswordSelector struct {
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default="NeutronPassword"
 	// Database - Selector to get the neutron service password from the Secret
-	Service string `json:"admin,omitempty"`
+	Service string `json:"service,omitempty"`
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default="NovaPassword"
 	// Database - Selector to get the nova service password from the Secret
-	NovaService string `json:"novaadmin,omitempty"`
+	NovaService string `json:"novaservice,omitempty"`
 }
 
 // NeutronAPIDebug defines the observed state of NeutronAPIDebug

--- a/config/crd/bases/neutron.openstack.org_neutronapis.yaml
+++ b/config/crd/bases/neutron.openstack.org_neutronapis.yaml
@@ -102,23 +102,27 @@ spec:
                   SBConnection string
                 type: string
               passwordSelectors:
+                default:
+                  database: NeutronDatabasePassword
+                  novaservice: NovaPassword
+                  service: NeutronPassword
                 description: PasswordSelectors - Selectors to identify the DB and
-                  AdminUser password from the Secret
+                  ServiceUser and NoveService User password from the Secret
                 properties:
-                  admin:
-                    default: NeutronPassword
-                    description: Database - Selector to get the neutron service password
-                      from the Secret
-                    type: string
                   database:
                     default: NeutronDatabasePassword
                     description: 'Database - Selector to get the neutron database
                       user password from the Secret TODO: not used, need change in
                       mariadb-operator'
                     type: string
-                  novaadmin:
+                  novaservice:
                     default: NovaPassword
                     description: Database - Selector to get the nova service password
+                      from the Secret
+                    type: string
+                  service:
+                    default: NeutronPassword
+                    description: Database - Selector to get the neutron service password
                       from the Secret
                     type: string
                 type: object


### PR DESCRIPTION
When a CRD has an optional struct field the defaulting of that field needs special care. Both the field with the struct type need a full default value defined and each individual subfields in the struct needs default value defined. Otherwise in the first reconcile call the PasswordSelectors is empty and then in the second reconcile it is filled.

Now documented via https://github.com/openstack-k8s-operators/docs/pull/12