### PR TITLE
Fix rbac for OVNDBCluster

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -138,7 +138,7 @@ rules:
 - apiGroups:
   - ovn.openstack.org
   resources:
-  - ovndbcluster
+  - ovndbclusters
   verbs:
   - get
   - list

--- a/controllers/neutronapi_controller.go
+++ b/controllers/neutronapi_controller.go
@@ -88,7 +88,7 @@ func (r *NeutronAPIReconciler) GetScheme() *runtime.Scheme {
 // +kubebuilder:rbac:groups=keystone.openstack.org,resources=keystoneapis,verbs=get;list;watch;
 // +kubebuilder:rbac:groups=keystone.openstack.org,resources=keystoneservices,verbs=get;list;watch;create;update;patch;delete;
 // +kubebuilder:rbac:groups=keystone.openstack.org,resources=keystoneendpoints,verbs=get;list;watch;create;update;patch;delete;
-// +kubebuilder:rbac:groups=ovn.openstack.org,resources=ovndbcluster,verbs=get;list;watch;
+// +kubebuilder:rbac:groups=ovn.openstack.org,resources=ovndbclusters,verbs=get;list;watch;
 
 // Reconcile - neutron api
 func (r *NeutronAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {


### PR DESCRIPTION
Previous commit wrongly set it to ovndbcluster,
it should be "ovndbclusters" instead.