### PR TITLE
use stable/zed containers

### DIFF
--- a/api/bases/neutron.openstack.org_neutronapis.yaml
+++ b/api/bases/neutron.openstack.org_neutronapis.yaml
@@ -45,6 +45,7 @@ spec:
             description: NeutronAPISpec defines the desired state of NeutronAPI
             properties:
               containerImage:
+                default: quay.io/tripleozedcentos9/openstack-neutron-server:current-tripleo
                 type: string
               customServiceConfig:
                 default: '# add your customization here'

--- a/api/v1beta1/neutronapi_types.go
+++ b/api/v1beta1/neutronapi_types.go
@@ -61,6 +61,8 @@ type NeutronAPISpec struct {
 	// TODO: -> implement needs work in mariadb-operator, right now only neutron
 	DatabaseUser string `json:"databaseUser"`
 
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default="quay.io/tripleozedcentos9/openstack-neutron-server:current-tripleo"
 	ContainerImage string `json:"containerImage,omitempty"`
 
 	// +kubebuilder:validation:Optional

--- a/config/crd/bases/neutron.openstack.org_neutronapis.yaml
+++ b/config/crd/bases/neutron.openstack.org_neutronapis.yaml
@@ -45,6 +45,7 @@ spec:
             description: NeutronAPISpec defines the desired state of NeutronAPI
             properties:
               containerImage:
+                default: quay.io/tripleozedcentos9/openstack-neutron-server:current-tripleo
                 type: string
               customServiceConfig:
                 default: '# add your customization here'

--- a/config/samples/neutron_v1beta1_neutronapi.yaml
+++ b/config/samples/neutron_v1beta1_neutronapi.yaml
@@ -14,6 +14,6 @@ spec:
     dbSync: false
     service: false
   preserveJobs: false
-  containerImage: quay.io/tripleowallabycentos9/openstack-neutron-server:current-tripleo
+  containerImage: quay.io/tripleozedcentos9/openstack-neutron-server:current-tripleo
   replicas: 1
   secret: neutron-secret


### PR DESCRIPTION
This change makes the container image optional and sets
the default to use the stable/zed image.
