### PR TITLE
Set ovn_metadata_enabled to True by default

### DIFF
--- a/templates/neutronapi/config/neutron.conf
+++ b/templates/neutronapi/config/neutron.conf
@@ -29,6 +29,7 @@ enable_security_group = true
 ovn_nb_connection = {{ .NBConnection }}
 ovn_sb_connection = {{ .SBConnection }}
 ovn_l3_scheduler = leastloaded
+ovn_metadata_enabled = True
 
 [keystone_authtoken]
 www_authenticate_uri = {{ .KeystonePublicURL }}


### PR DESCRIPTION
We enable metadata service in compute nodes by
default, and in order to have metadata/dhcp
port created with networks we require to set
config option [ovn]/ovn_metadata_enabled to True.