### PR TITLE
Drop removed [DEFAULT] allow_overlapping_ips

### DIFF
--- a/templates/neutronapi/config/neutron.conf
+++ b/templates/neutronapi/config/neutron.conf
@@ -4,7 +4,6 @@ auth_strategy = keystone
 core_plugin = neutron.plugins.ml2.plugin.Ml2Plugin
 service_plugins = qos,ovn-router,trunk,segments,port_forwarding,log
 dns_domain = openstackgate.local
-allow_overlapping_ips = true
 
 dhcp_agent_notification = false
 


### PR DESCRIPTION
This option was already removed from Neutron during Zed cycle[1].

[1] https://review.opendev.org/c/openstack/neutron/+/837286