### PR TITLE
Use internal endpoint to interact with Keystone/Nova

### DIFF
--- a/controllers/neutronapi_controller.go
+++ b/controllers/neutronapi_controller.go
@@ -760,13 +760,18 @@ func (r *NeutronAPIReconciler) generateServiceConfigMaps(
 	if err != nil {
 		return err
 	}
-	authURL, err := keystoneAPI.GetEndpoint(endpoint.EndpointPublic)
+	keystoneInternalURL, err := keystoneAPI.GetEndpoint(endpoint.EndpointInternal)
+	if err != nil {
+		return err
+	}
+	keystonePublicURL, err := keystoneAPI.GetEndpoint(endpoint.EndpointPublic)
 	if err != nil {
 		return err
 	}
 	templateParameters := make(map[string]interface{})
 	templateParameters["ServiceUser"] = instance.Spec.ServiceUser
-	templateParameters["KeystonePublicURL"] = authURL
+	templateParameters["KeystoneInternalURL"] = keystoneInternalURL
+	templateParameters["KeystonePublicURL"] = keystonePublicURL
 
 	templateParameters["NBConnection"] = dbmap["NB"]
 	templateParameters["SBConnection"] = dbmap["SB"]

--- a/templates/neutronapi/config/neutron.conf
+++ b/templates/neutronapi/config/neutron.conf
@@ -33,7 +33,7 @@ ovn_metadata_enabled = True
 
 [keystone_authtoken]
 www_authenticate_uri = {{ .KeystonePublicURL }}
-auth_url = {{ .KeystonePublicURL }}
+auth_url = {{ .KeystoneInternalURL }}
 # XXX(mdbooth): Add memcached
 #memcached_servers = controller:11211
 auth_type = password
@@ -41,14 +41,16 @@ project_domain_name = Default
 user_domain_name = Default
 project_name = service
 username = {{ .ServiceUser }}
+interface = internal
 
 [nova]
-auth_url = {{ .KeystonePublicURL }}
+auth_url = {{ .KeystoneInternalURL }}
 auth_type = password
 project_domain_name = Default
 user_domain_name = default
 region_name = regionOne
 username = nova
+endpoint_type = internal
 
 [oslo_concurrency]
 lock_path = /var/lib/neutron/tmp


### PR DESCRIPTION
Internal endpoint is meant for interaction between services. This ensures neutron uses internal endpoints when it sends requests to the other services.