### PR TITLE
Use own user to send admin requests to nova

### DIFF
--- a/api/bases/neutron.openstack.org_neutronapis.yaml
+++ b/api/bases/neutron.openstack.org_neutronapis.yaml
@@ -111,7 +111,6 @@ spec:
               passwordSelectors:
                 default:
                   database: NeutronDatabasePassword
-                  novaservice: NovaPassword
                   service: NeutronPassword
                 description: PasswordSelectors - Selectors to identify the DB and
                   ServiceUser and NoveService User password from the Secret
@@ -121,11 +120,6 @@ spec:
                     description: 'Database - Selector to get the neutron database
                       user password from the Secret TODO: not used, need change in
                       mariadb-operator'
-                    type: string
-                  novaservice:
-                    default: NovaPassword
-                    description: Database - Selector to get the nova service password
-                      from the Secret
                     type: string
                   service:
                     default: NeutronPassword
@@ -199,7 +193,7 @@ spec:
                 type: object
               secret:
                 description: Secret containing OpenStack password information for
-                  neutron NeutronPassword NovaPassword
+                  NeutronDatabasePassword, NeutronPassword
                 type: string
               serviceUser:
                 default: neutron

--- a/api/v1beta1/neutronapi_types.go
+++ b/api/v1beta1/neutronapi_types.go
@@ -79,12 +79,12 @@ type NeutronAPISpec struct {
 	Replicas int32 `json:"replicas"`
 
 	// +kubebuilder:validation:Required
-	// Secret containing OpenStack password information for neutron NeutronPassword NovaPassword
+	// Secret containing OpenStack password information for NeutronDatabasePassword, NeutronPassword
 	Secret string `json:"secret"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default={database: NeutronDatabasePassword, service: NeutronPassword, novaservice: NovaPassword}
-	// PasswordSelectors - Selectors to identify the DB and ServiceUser and NoveService User password from the Secret
+	// +kubebuilder:default={database: NeutronDatabasePassword, service: NeutronPassword}
+	// PasswordSelectors - Selectors to identify the DB and ServiceUser password from the Secret
 	PasswordSelectors PasswordSelector `json:"passwordSelectors,omitempty"`
 
 	// +kubebuilder:validation:Optional
@@ -135,10 +135,6 @@ type PasswordSelector struct {
 	// +kubebuilder:default="NeutronPassword"
 	// Database - Selector to get the neutron service password from the Secret
 	Service string `json:"service,omitempty"`
-	// +kubebuilder:validation:Optional
-	// +kubebuilder:default="NovaPassword"
-	// Database - Selector to get the nova service password from the Secret
-	NovaService string `json:"novaservice,omitempty"`
 }
 
 // NeutronAPIDebug defines the observed state of NeutronAPIDebug

--- a/config/crd/bases/neutron.openstack.org_neutronapis.yaml
+++ b/config/crd/bases/neutron.openstack.org_neutronapis.yaml
@@ -111,7 +111,6 @@ spec:
               passwordSelectors:
                 default:
                   database: NeutronDatabasePassword
-                  novaservice: NovaPassword
                   service: NeutronPassword
                 description: PasswordSelectors - Selectors to identify the DB and
                   ServiceUser and NoveService User password from the Secret
@@ -121,11 +120,6 @@ spec:
                     description: 'Database - Selector to get the neutron database
                       user password from the Secret TODO: not used, need change in
                       mariadb-operator'
-                    type: string
-                  novaservice:
-                    default: NovaPassword
-                    description: Database - Selector to get the nova service password
-                      from the Secret
                     type: string
                   service:
                     default: NeutronPassword
@@ -199,7 +193,7 @@ spec:
                 type: object
               secret:
                 description: Secret containing OpenStack password information for
-                  neutron NeutronPassword NovaPassword
+                  NeutronDatabasePassword, NeutronPassword
                 type: string
               serviceUser:
                 default: neutron

--- a/config/samples/neutron-secret.yaml
+++ b/config/samples/neutron-secret.yaml
@@ -6,4 +6,3 @@ stringData:
   DatabasePassword: "12345678"
   NeutronPassword: foobar123
   TransportUrl: "amqp://osp:passw0rd@amq-interconnect.openstack.svc:5672"
-  NovaPassword: foobar123

--- a/pkg/neutronapi/dbsync.go
+++ b/pkg/neutronapi/dbsync.go
@@ -70,7 +70,6 @@ func DbSyncJob(
 		NeutronSecret:        cr.Spec.Secret,
 		DBPasswordSelector:   cr.Spec.PasswordSelectors.Database,
 		UserPasswordSelector: cr.Spec.PasswordSelectors.Service,
-		NovaPasswordSelector: cr.Spec.PasswordSelectors.NovaService,
 		VolumeMounts:         initVolumeMounts,
 	}
 	job.Spec.Template.Spec.InitContainers = GetInitContainer(initContainerDetails)

--- a/pkg/neutronapi/dbsync.go
+++ b/pkg/neutronapi/dbsync.go
@@ -66,6 +66,7 @@ func DbSyncJob(
 	initContainerDetails := InitContainer{
 		ContainerImage:       cr.Spec.ContainerImage,
 		DatabaseHost:         cr.Status.DatabaseHostname,
+		DatabaseUser:         cr.Spec.DatabaseUser,
 		Database:             Database,
 		NeutronSecret:        cr.Spec.Secret,
 		DBPasswordSelector:   cr.Spec.PasswordSelectors.Database,

--- a/pkg/neutronapi/deployment.go
+++ b/pkg/neutronapi/deployment.go
@@ -153,6 +153,7 @@ func Deployment(
 	initContainerDetails := InitContainer{
 		ContainerImage:       instance.Spec.ContainerImage,
 		DatabaseHost:         instance.Status.DatabaseHostname,
+		DatabaseUser:         instance.Spec.DatabaseUser,
 		Database:             Database,
 		NeutronSecret:        instance.Spec.Secret,
 		TransportURLSecret:   instance.Status.TransportURLSecret,

--- a/pkg/neutronapi/deployment.go
+++ b/pkg/neutronapi/deployment.go
@@ -158,7 +158,6 @@ func Deployment(
 		TransportURLSecret:   instance.Status.TransportURLSecret,
 		DBPasswordSelector:   instance.Spec.PasswordSelectors.Database,
 		UserPasswordSelector: instance.Spec.PasswordSelectors.Service,
-		NovaPasswordSelector: instance.Spec.PasswordSelectors.NovaService,
 		VolumeMounts:         GetInitVolumeMounts(),
 	}
 	deployment.Spec.Template.Spec.InitContainers = GetInitContainer(initContainerDetails)

--- a/pkg/neutronapi/initcontainer.go
+++ b/pkg/neutronapi/initcontainer.go
@@ -13,7 +13,6 @@ type InitContainer struct {
 	NeutronSecret        string
 	TransportURLSecret   string
 	DBPasswordSelector   string
-	NovaPasswordSelector string
 	UserPasswordSelector string
 	VolumeMounts         []corev1.VolumeMount
 }
@@ -58,17 +57,6 @@ func GetInitContainer(init InitContainer) []corev1.Container {
 						Name: init.NeutronSecret,
 					},
 					Key: init.UserPasswordSelector,
-				},
-			},
-		},
-		{
-			Name: "NovaPassword",
-			ValueFrom: &corev1.EnvVarSource{
-				SecretKeyRef: &corev1.SecretKeySelector{
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: init.NeutronSecret,
-					},
-					Key: init.NovaPasswordSelector,
 				},
 			},
 		},

--- a/pkg/neutronapi/initcontainer.go
+++ b/pkg/neutronapi/initcontainer.go
@@ -10,6 +10,7 @@ type InitContainer struct {
 	ContainerImage       string
 	Database             string
 	DatabaseHost         string
+	DatabaseUser         string
 	NeutronSecret        string
 	TransportURLSecret   string
 	DBPasswordSelector   string
@@ -37,6 +38,10 @@ func GetInitContainer(init InitContainer) []corev1.Container {
 		{
 			Name:  "Database",
 			Value: init.Database,
+		},
+		{
+			Name:  "DatabaseUser",
+			Value: init.DatabaseUser,
 		},
 		{
 			Name: "DatabasePassword",

--- a/templates/neutronapi/bin/init.sh
+++ b/templates/neutronapi/bin/init.sh
@@ -21,8 +21,7 @@ set -ex
 # Secrets are obtained from ENV variables.
 export Database=${Database:-"neutron"}
 export DatabaseHost=${DatabaseHost:?"Please specify a DatabaseHost variable."}
-export NeutronPassword=${NeutronPassword:?"Please specify a NeutronPassword variable."}
-export NovaPassword=${NovaPassword:?"Please specify a NovaPassword variable."}
+export Password=${NeutronPassword:?"Please specify a NeutronPassword variable."}
 export DatabasePassword=${DatabasePassword:?"Please specify a DatabasePassword variable."}
 export TransportUrl=${TransportURL:-""}
 
@@ -56,5 +55,5 @@ if [ -n "$TransportUrl" ]; then
     crudini --set /var/lib/config-data/merged/neutron.conf DEFAULT transport_url $TransportUrl
 fi
 crudini --set /var/lib/config-data/merged/neutron.conf database connection mysql+pymysql://$Database:$DatabasePassword@$DatabaseHost/$Database
-crudini --set /var/lib/config-data/merged/neutron.conf keystone_authtoken password $NeutronPassword
-crudini --set /var/lib/config-data/merged/neutron.conf nova password $NovaPassword
+crudini --set /var/lib/config-data/merged/neutron.conf keystone_authtoken password $Password
+crudini --set /var/lib/config-data/merged/neutron.conf nova password $Password

--- a/templates/neutronapi/bin/init.sh
+++ b/templates/neutronapi/bin/init.sh
@@ -19,11 +19,11 @@ set -ex
 # copies the result to the ephemeral /var/lib/config-data/merged volume.
 #
 # Secrets are obtained from ENV variables.
-export Database=${Database:-"neutron"}
-export DatabaseHost=${DatabaseHost:?"Please specify a DatabaseHost variable."}
-export Password=${NeutronPassword:?"Please specify a NeutronPassword variable."}
-export DatabasePassword=${DatabasePassword:?"Please specify a DatabasePassword variable."}
-export TransportUrl=${TransportURL:-""}
+export DB=${Database:-"neutron"}
+export PASSWORD=${NeutronPassword:?"Please specify a NeutronPassword variable."}
+export DBHOST=${DatabaseHost:?"Please specify a DatabaseHost variable."}
+export DBPASSWORD=${DatabasePassword:?"Please specify a DatabasePassword variable."}
+export TRANSPORTURL=${TransportURL:-""}
 
 function merge_config_dir {
     echo merge config dir $1
@@ -51,9 +51,9 @@ if [[ -d /var/lib/config-data/default ]]; then
 fi
 
 # set secrets
-if [ -n "$TransportUrl" ]; then
-    crudini --set /var/lib/config-data/merged/neutron.conf DEFAULT transport_url $TransportUrl
+if [ -n "$TRANSPORTURL" ]; then
+    crudini --set /var/lib/config-data/merged/neutron.conf DEFAULT transport_url $TRANSPORTURL
 fi
-crudini --set /var/lib/config-data/merged/neutron.conf database connection mysql+pymysql://$Database:$DatabasePassword@$DatabaseHost/$Database
-crudini --set /var/lib/config-data/merged/neutron.conf keystone_authtoken password $Password
-crudini --set /var/lib/config-data/merged/neutron.conf nova password $Password
+crudini --set /var/lib/config-data/merged/neutron.conf database connection mysql+pymysql://${DB}:${DBPASSWORD}@${DBHOST}/${DB}
+crudini --set /var/lib/config-data/merged/neutron.conf keystone_authtoken password $PASSWORD
+crudini --set /var/lib/config-data/merged/neutron.conf nova password $PASSWORD

--- a/templates/neutronapi/bin/init.sh
+++ b/templates/neutronapi/bin/init.sh
@@ -22,6 +22,7 @@ set -ex
 export DB=${Database:-"neutron"}
 export PASSWORD=${NeutronPassword:?"Please specify a NeutronPassword variable."}
 export DBHOST=${DatabaseHost:?"Please specify a DatabaseHost variable."}
+export DBUSER=${DatabaseUser:?"Please specify a DatabaseUser variable."}
 export DBPASSWORD=${DatabasePassword:?"Please specify a DatabasePassword variable."}
 export TRANSPORTURL=${TransportURL:-""}
 
@@ -54,6 +55,6 @@ fi
 if [ -n "$TRANSPORTURL" ]; then
     crudini --set /var/lib/config-data/merged/neutron.conf DEFAULT transport_url $TRANSPORTURL
 fi
-crudini --set /var/lib/config-data/merged/neutron.conf database connection mysql+pymysql://${DB}:${DBPASSWORD}@${DBHOST}/${DB}
+crudini --set /var/lib/config-data/merged/neutron.conf database connection mysql+pymysql://${DBUSER}:${DBPASSWORD}@${DBHOST}/${DB}
 crudini --set /var/lib/config-data/merged/neutron.conf keystone_authtoken password $PASSWORD
 crudini --set /var/lib/config-data/merged/neutron.conf nova password $PASSWORD

--- a/templates/neutronapi/config/neutron.conf
+++ b/templates/neutronapi/config/neutron.conf
@@ -46,9 +46,9 @@ interface = internal
 auth_url = {{ .KeystoneInternalURL }}
 auth_type = password
 project_domain_name = Default
-user_domain_name = default
+user_domain_name = Default
 region_name = regionOne
-username = nova
+username = {{ .ServiceUser }}
 endpoint_type = internal
 
 [oslo_concurrency]


### PR DESCRIPTION
... instead of nova user. This allows us to reduce dependency on the resources managed by nova-operator and better separate each operators. The credential should work fine as long as the user has admin access with the 'service' project scope.