### PR TITLE
Fix pattern to exclude bin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 *.dll
 *.so
 *.dylib
-bin
+/bin
 testbin/*
 
 # Test binary, build with `go test -c`


### PR DESCRIPTION
Current pattern can match subdirectories and makes some files in templates directories excluded.

Signed-off-by: Takashi Kajinami <tkajinam@redhat.com>