### PR TITLE
Return error in ConfigMap creation

### DIFF
--- a/controllers/neutronapi_controller.go
+++ b/controllers/neutronapi_controller.go
@@ -790,11 +790,7 @@ func (r *NeutronAPIReconciler) generateServiceConfigMaps(
 			ConfigOptions: templateParameters,
 		},
 	}
-	err = configmap.EnsureConfigMaps(ctx, h, instance, cms, envVars)
-	if err != nil {
-		return nil
-	}
-	return nil
+	return configmap.EnsureConfigMaps(ctx, h, instance, cms, envVars)
 }
 
 // createHashOfInputHashes - creates a hash of hashes which gets added to the resources which requires a restart


### PR DESCRIPTION
The current logic ignores the error but it should be returned so that the error can be detected in the reconciler.