### PR TITLE
Add basic KUTTL tests for neutron-operator

### DIFF
--- a/kuttl-test.yaml
+++ b/kuttl-test.yaml
@@ -1,0 +1,25 @@
+#
+# EXECUTION (from install_yamls repo root):
+#
+#   make neutron_kuttl
+#
+# ASSUMPTIONS:
+#
+# 1. Latest version of kuttl is installed at /usr/local/bin/kubectl-kuttl
+#    - wget https://github.com/kudobuilder/kuttl/releases/download/v0.11.1/kubectl-kuttl_0.11.1_linux_x86_64
+#    - mv kubectl-kuttl_0.11.1_linux_x86_64 /usr/local/bin/kubectl-kuttl
+#    - chmod 755 /usr/local/bin/kubectl-kuttl
+# 2. An OCP 4.10+ CRC cluster with Podified Operators has been deployed
+# 3. CLI user has access to $KUBECONFIG
+# 4. The environment variable INSTALL_YAMLS is set to the the path of the
+#    install_yamls repo
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestSuite
+reportFormat: JSON
+reportName: kuttl-test-neutron
+namespace: openstack
+timeout: 180
+parallel: 1
+suppress:
+  - events                     # Remove spammy event logs

--- a/test/kuttl/common/assert_sample_deployment.yaml
+++ b/test/kuttl/common/assert_sample_deployment.yaml
@@ -1,0 +1,297 @@
+#
+# Check for:
+#
+# - 1 NeutronAPI CR
+# - Deployment with 1 Pod for NeutronAPI CR
+# - Neutron-admin Service
+# - Neutron-internal Service
+# - Neutron-public Service
+# - Neutron-admin Route
+# - Neutron-internal Route
+# - Neutron-public Route
+
+apiVersion: neutron.openstack.org/v1beta1
+kind: NeutronAPI
+metadata:
+  finalizers:
+  - NeutronAPI
+  name: neutron
+  namespace: openstack
+spec:
+  containerImage: quay.io/tripleozedcentos9/openstack-neutron-server:current-tripleo
+  customServiceConfig: |
+    [DEFAULT]
+    debug = true
+  databaseInstance: openstack
+  databaseUser: neutron
+  debug:
+    bootstrap: false
+    dbSync: false
+    service: false
+  passwordSelectors:
+    database: NeutronDatabasePassword
+    service: NeutronPassword
+  preserveJobs: false
+  rabbitMqClusterName: rabbitmq
+  replicas: 1
+  secret: osp-secret
+  serviceUser: neutron
+status:
+  databaseHostname: openstack
+  transportURLSecret: rabbitmq-transport-url-neutron-neutron-transport
+  readyCount: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: neutron
+  namespace: openstack
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      service: neutron
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        service: neutron
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: service
+                  operator: In
+                  values:
+                  - neutron
+              topologyKey: kubernetes.io/hostname
+            weight: 1
+      containers:
+      - args:
+        - -c
+        - /usr/local/bin/kolla_set_configs && /usr/local/bin/kolla_start
+        command:
+        - /bin/bash
+        image: quay.io/tripleozedcentos9/openstack-neutron-server:current-tripleo
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /
+            port: 9696
+            scheme: HTTP
+          initialDelaySeconds: 20
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 5
+        name: neutron-api
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /
+            port: 9696
+            scheme: HTTP
+          initialDelaySeconds: 20
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 5
+        resources: {}
+        securityContext:
+          runAsUser: 0
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: FallbackToLogsOnError
+      initContainers:
+      - command:
+        - /bin/bash
+        - -c
+        - /usr/local/bin/container-scripts/init.sh
+        env:
+        - name: DatabaseHost
+          value: openstack
+        - name: Database
+          value: neutron
+        - name: DatabaseUser
+          value: neutron
+        - name: DatabasePassword
+          valueFrom:
+            secretKeyRef:
+              key: NeutronDatabasePassword
+              name: osp-secret
+        - name: NeutronPassword
+          valueFrom:
+            secretKeyRef:
+              key: NeutronPassword
+              name: osp-secret
+        - name: TransportURL
+          valueFrom:
+            secretKeyRef:
+              key: transport_url
+              name: rabbitmq-transport-url-neutron-neutron-transport
+        image: quay.io/tripleozedcentos9/openstack-neutron-server:current-tripleo
+        imagePullPolicy: IfNotPresent
+        name: init
+        resources: {}
+        securityContext:
+          runAsUser: 0
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      schedulerName: default-scheduler
+      securityContext: {}
+      serviceAccount: neutron-operator-neutron
+      serviceAccountName: neutron-operator-neutron
+      terminationGracePeriodSeconds: 30
+status:
+  availableReplicas: 1
+  readyReplicas: 1
+  replicas: 1
+  updatedReplicas: 1
+---
+# the openshift annotations can't be checked through the deployment above
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    openshift.io/scc: privileged
+  labels:
+    service: neutron
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    admin: "true"
+    service: neutron
+  name: neutron-admin
+  namespace: openstack
+spec:
+  internalTrafficPolicy: Cluster
+  ipFamilies:
+    - IPv4
+  ipFamilyPolicy: SingleStack
+  ports:
+  - name: neutron-admin
+    port: 9696
+    protocol: TCP
+    targetPort: 9696
+  selector:
+    service: neutron
+  sessionAffinity: None
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    internal: "true"
+    service: neutron
+  name: neutron-internal
+  namespace: openstack
+spec:
+  internalTrafficPolicy: Cluster
+  ipFamilies:
+  - IPv4
+  ipFamilyPolicy: SingleStack
+  ports:
+  - name: neutron-internal
+    port: 9696
+    protocol: TCP
+    targetPort: 9696
+  selector:
+    service: neutron
+  sessionAffinity: None
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    public: "true"
+    service: neutron
+  name: neutron-public
+  namespace: openstack
+spec:
+  internalTrafficPolicy: Cluster
+  ipFamilies:
+  - IPv4
+  ipFamilyPolicy: SingleStack
+  ports:
+  - name: neutron-public
+    port: 9696
+    protocol: TCP
+    targetPort: 9696
+  selector:
+    service: neutron
+  sessionAffinity: None
+  type: ClusterIP
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: neutron-admin
+  labels:
+    admin: "true"
+    service: neutron
+  namespace: openstack
+spec:
+  port:
+    targetPort: neutron-admin
+  to:
+    kind: Service
+    name: neutron-admin
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: neutron-internal
+  labels:
+    internal: "true"
+    service: neutron
+  namespace: openstack
+spec:
+  port:
+    targetPort: neutron-internal
+  to:
+    kind: Service
+    name: neutron-internal
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: neutron-public
+  labels:
+    public: "true"
+    service: neutron
+  namespace: openstack
+spec:
+  port:
+    targetPort: neutron-public
+  to:
+    kind: Service
+    name: neutron-public
+---
+# the actual addresses of the apiEndpoints are platform specific, so we can't rely on 
+# kuttl asserts to check them. This short script gathers the addresses and checks that
+# the three endpoints are defined and their addresses follow the default pattern
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+namespaced: true
+commands:
+  - script: |
+      template='{{.status.apiEndpoint.admin}}{{":"}}{{.status.apiEndpoint.internal}}{{":"}}{{.status.apiEndpoint.public}}{{"\n"}}'                                                        
+      regex="http:\/\/neutron-admin-openstack\.apps.*:http:\/\/neutron-internal-openstack\.apps.*:http:\/\/neutron-public-openstack\.apps.*"
+      apiEndpoints=$(oc get -n openstack NeutronAPI neutron -o go-template="$template") 
+      matches=$(echo "$apiEndpoints" | sed -e "s?$regex??")
+      if [[ -z "$matches" ]]; then
+        exit 0
+      else
+        exit 1
+      fi

--- a/test/kuttl/common/cleanup-neutron.yaml
+++ b/test/kuttl/common/cleanup-neutron.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: |
+      PWD=$INSTALL_YAMLS
+      make -C $INSTALL_YAMLS neutron_deploy_cleanup

--- a/test/kuttl/common/deploy_neutron.yaml
+++ b/test/kuttl/common/deploy_neutron.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: |
+      PWD=$INSTALL_YAMLS
+      make -C $INSTALL_YAMLS neutron_deploy

--- a/test/kuttl/common/errors_cleanup_neutron.yaml
+++ b/test/kuttl/common/errors_cleanup_neutron.yaml
@@ -1,0 +1,85 @@
+#
+# Check for:
+#
+# No NeutronAPI CR
+# No Deployment for NeutronAPI CR
+# No Pods in neutron Deployment
+# No Neutron Services
+# No Neutron Routes
+#
+apiVersion: neutron.openstack.org/v1beta1
+kind: NeutronAPI
+metadata:
+  finalizers:
+  - NeutronAPI
+  name: neutron
+  namespace: openstack
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: neutron
+  namespace: openstack
+---
+# the openshift annotations can't be checked through the deployment above
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    openshift.io/scc: anyuid
+  labels:
+    service: neutron
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    admin: "true"
+    service: neutron
+  name: neutron-admin
+  namespace: openstack
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    internal: "true"
+    service: neutron
+  name: neutron-internal
+  namespace: openstack
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    public: "true"
+    service: neutron
+  name: neutron-public
+  namespace: openstack
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: neutron-admin
+  labels:
+    admin: "true"
+    service: neutron
+  namespace: openstack
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: neutron-internal
+  labels:
+    internal: "true"
+    service: neutron
+  namespace: openstack
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: neutron-public
+  labels:
+    public: "true"
+    service: neutron
+  namespace: openstack

--- a/test/kuttl/tests/neutron_scale/01-assert.yaml
+++ b/test/kuttl/tests/neutron_scale/01-assert.yaml
@@ -1,0 +1,1 @@
+../../common/assert_sample_deployment.yaml

--- a/test/kuttl/tests/neutron_scale/01-deploy-neutron.yaml
+++ b/test/kuttl/tests/neutron_scale/01-deploy-neutron.yaml
@@ -1,0 +1,1 @@
+../../common/deploy_neutron.yaml

--- a/test/kuttl/tests/neutron_scale/02-assert.yaml
+++ b/test/kuttl/tests/neutron_scale/02-assert.yaml
@@ -1,0 +1,27 @@
+#
+# Check for:
+#
+# - 1 NeutronAPI CR
+# - 3 Pods for NeutronAPI CR
+#
+
+apiVersion: neutron.openstack.org/v1beta1
+kind: NeutronAPI
+metadata:
+  finalizers:
+  - NeutronAPI
+  name: neutron
+  namespace: openstack
+spec:
+  replicas: 3
+status:
+  readyCount: 3
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: neutron
+spec:
+  replicas: 3
+status:
+  availableReplicas: 3

--- a/test/kuttl/tests/neutron_scale/02-scale-neutronapi.yaml
+++ b/test/kuttl/tests/neutron_scale/02-scale-neutronapi.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: |
+      oc patch neutronapi -n openstack neutron --type='json' -p='[{"op": "replace", "path": "/spec/replicas", "value":3}]'

--- a/test/kuttl/tests/neutron_scale/03-assert.yaml
+++ b/test/kuttl/tests/neutron_scale/03-assert.yaml
@@ -1,0 +1,28 @@
+#
+# Check for:
+#
+# - 1 NeutronAPI CR
+# - 1 Pods for NeutronAPI CR
+#
+
+apiVersion: neutron.openstack.org/v1beta1
+kind: NeutronAPI
+metadata:
+  finalizers:
+  - NeutronAPI
+  name: neutron
+  namespace: openstack
+spec:
+  replicas: 1
+status:
+  readyCount: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: neutron
+  namespace: openstack
+spec:
+  replicas: 1
+status:
+  availableReplicas: 1

--- a/test/kuttl/tests/neutron_scale/03-scale-down-neutronapi.yaml
+++ b/test/kuttl/tests/neutron_scale/03-scale-down-neutronapi.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: |
+      oc patch neutronapi -n openstack neutron --type='json' -p='[{"op": "replace", "path": "/spec/replicas", "value":1}]'

--- a/test/kuttl/tests/neutron_scale/04-assert.yaml
+++ b/test/kuttl/tests/neutron_scale/04-assert.yaml
@@ -1,0 +1,23 @@
+#
+# Check for:
+#
+# - NeutronAPI CR with no replicas
+# - Neutron Deployment with 0 Pods
+#
+
+apiVersion: neutron.openstack.org/v1beta1
+kind: NeutronAPI
+metadata:
+  finalizers:
+  - NeutronAPI
+  name: neutron
+  namespace: openstack
+spec:
+  replicas: 0
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: neutron
+spec:
+  replicas: 0

--- a/test/kuttl/tests/neutron_scale/04-errors.yaml
+++ b/test/kuttl/tests/neutron_scale/04-errors.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    openshift.io/scc: anyuid
+  labels:
+    service: neutron

--- a/test/kuttl/tests/neutron_scale/04-scale-down-zero-neutronapi.yaml
+++ b/test/kuttl/tests/neutron_scale/04-scale-down-zero-neutronapi.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: |
+      oc patch neutronapi -n openstack neutron --type='json' -p='[{"op": "replace", "path": "/spec/replicas", "value":0}]'

--- a/test/kuttl/tests/neutron_scale/05-cleanup-neutron.yaml
+++ b/test/kuttl/tests/neutron_scale/05-cleanup-neutron.yaml
@@ -1,0 +1,1 @@
+../../common/cleanup-neutron.yaml

--- a/test/kuttl/tests/neutron_scale/05-errors.yaml
+++ b/test/kuttl/tests/neutron_scale/05-errors.yaml
@@ -1,0 +1,1 @@
+../../common/errors_cleanup_neutron.yaml


### PR DESCRIPTION
These tests cover basic operations: deployment, scale up, scale down and clean up.

The tests use code from the install_yamls repo to reuse some operations like
the deployment of the neutron operator, as well as the cleanup from previous runs.

Test are thought to be run from the `install_yamls` repo, see the following
PR: https://github.com/openstack-k8s-operators/install_yamls/pull/99

There are three ways to run the tests:
1) Run `make neutron_kuttl`, this will only work if you want to run the test
from the master branch.
2) Run `make neutron_kuttl NEUTRON_REPO=ovs-operator._repo_url
NEUTRON_BRANCH=branch_name` this is useful if you want to run the tests from
a fork
3) Run `make neutron_kuttl
NEUTRON_KUTTL_CONF=/path/to/neutron-operator/kuttl-test.yaml
NEUTRON_KUTTL_DIR=/path/to/neutron-operator/tests/kuttl/tests/` this is
useful to run local changes to the tests
