### PR TITLE
Pass GITHUB_TOKEN to install_kustomize.sh to avoid rate-limit

### DIFF
--- a/.github/workflows/build-neutron-operator.yaml
+++ b/.github/workflows/build-neutron-operator.yaml
@@ -117,6 +117,7 @@ jobs:
         REGISTRY:  ${{ env.imageregistry }}/${{ env.imagenamespace }}
         GITHUB_SHA: ${{ github.sha }}
         BASE_IMAGE: neutron-operator
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Get branch name
       id: branch-name


### PR DESCRIPTION
We are hitting rate-limt during post merge image build:

  Github rate-limiter failed the request. Either authenticate or wait a couple of minutes.

It seems it is coming from [1] and can be fixed by passing the GITHUB_TOKEN there. So this patch does that to avoid build failures due to rate-limit.

[1] https://github.com/kubernetes-sigs/kustomize/blob/0fd385d7197026b92272dc8688ec66593be91fba/hack/install_kustomize.sh#L145