### PR TITLE
Run pre-commit with make

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,16 +1,32 @@
-ci:
-  autofix_prs: false
-  skip:
-   - 'make-manifests'
-   - 'make-generate'
-   - 'go-vet'
-   - 'golangci-lint'
-   - 'go-lint'
-   - 'make-operator-lint'
-
 repos:
+
 - repo: local
   hooks:
+    - id: golangci-lint
+      name: golangci-lint
+      language: golang
+      types: [go]
+      entry: make
+      args: ["golangci-lint"]
+      pass_filenames: false
+    - id: gofmt
+      name: gofmt
+      language: system
+      entry: make
+      args: ["fmt"]
+      pass_filenames: false
+    - id: govet
+      name: govet
+      language: system
+      entry: make
+      args: ["vet"]
+      pass_filenames: false
+    - id: gotidy
+      name: gotidy
+      language: system
+      entry: make
+      args: ["tidy"]
+      pass_filenames: false
     - id: make-manifests
       name: make-manifests
       language: system
@@ -29,20 +45,6 @@ repos:
       entry: make
       args: ['operator-lint']
       pass_filenames: false
-
-- repo: https://github.com/dnephin/pre-commit-golang
-  rev: v0.5.1
-  hooks:
-    - id: go-fmt
-      exclude: ^vendor
-    - id: go-vet
-    - id: go-mod-tidy
-    - id: go-lint
-
-- repo: https://github.com/golangci/golangci-lint
-  rev: v1.50.1
-  hooks:
-    - id: golangci-lint
 
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.4.0
@@ -72,4 +74,13 @@ repos:
   rev: 2.1.1
   hooks:
     - id: bashate
-      entry: bashate --error . --ignore=E006,E040,E011,E020,E012
+      entry: bashate --error . --ignore=E006,E040,E020,E012
+      # Run bashate check for all bash scripts
+      # Ignores the following rules:
+      # E006: Line longer than 79 columns (as many scripts use jinja
+      #       templating, this is very difficult)
+      # E040: Syntax error determined using `bash -n` (as many scripts
+      #       use jinja templating, this will often fail and the syntax
+      #       error will be discovered in execution anyway)
+      # E020: Function declaration not in format ^function name {$
+      # E012: here doc didn't end before EOF

--- a/Makefile
+++ b/Makefile
@@ -104,6 +104,18 @@ vet: gowork ## Run go vet against code.
 	go vet ./...
 	go vet ./api/...
 
+.PHONY: tidy
+tidy: fmt
+	go mod tidy; \
+	pushd "$(LOCALBIN)/../api/"; \
+	go mod tidy; \
+	popd
+
+.PHONY: golangci-lint
+golangci-lint:
+	test -s $(LOCALBIN)/golangci-lint || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.51.2
+	$(LOCALBIN)/golangci-lint run --fix
+
 PROCS?=$(shell expr $(shell nproc --ignore 2) / 2)
 PROC_CMD = --procs ${PROCS}
 
@@ -112,7 +124,6 @@ test: manifests generate fmt vet envtest ginkgo ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) -v debug --bin-dir $(LOCALBIN) use $(ENVTEST_K8S_VERSION) -p path)" $(GINKGO) --trace --cover --coverpkg=../../pkg/neutronapi,../../controllers,../../api/v1beta1 --coverprofile cover.out --covermode=atomic --randomize-all ${PROC_CMD} ./test/...
 
 ##@ Build
-
 .PHONY: build
 build: generate fmt vet ## Build manager binary.
 	go build -o bin/manager main.go

--- a/test/kuttl/common/assert_sample_deployment.yaml
+++ b/test/kuttl/common/assert_sample_deployment.yaml
@@ -278,7 +278,7 @@ spec:
     kind: Service
     name: neutron-public
 ---
-# the actual addresses of the apiEndpoints are platform specific, so we can't rely on 
+# the actual addresses of the apiEndpoints are platform specific, so we can't rely on
 # kuttl asserts to check them. This short script gathers the addresses and checks that
 # the three endpoints are defined and their addresses follow the default pattern
 apiVersion: kuttl.dev/v1beta1
@@ -286,9 +286,9 @@ kind: TestAssert
 namespaced: true
 commands:
   - script: |
-      template='{{.status.apiEndpoint.admin}}{{":"}}{{.status.apiEndpoint.internal}}{{":"}}{{.status.apiEndpoint.public}}{{"\n"}}'                                                        
+      template='{{.status.apiEndpoint.admin}}{{":"}}{{.status.apiEndpoint.internal}}{{":"}}{{.status.apiEndpoint.public}}{{"\n"}}'
       regex="http:\/\/neutron-admin-openstack\.apps.*:http:\/\/neutron-internal-openstack\.apps.*:http:\/\/neutron-public-openstack\.apps.*"
-      apiEndpoints=$(oc get -n openstack NeutronAPI neutron -o go-template="$template") 
+      apiEndpoints=$(oc get -n openstack NeutronAPI neutron -o go-template="$template")
       matches=$(echo "$apiEndpoints" | sed -e "s?$regex??")
       if [[ -z "$matches" ]]; then
         exit 0


### PR DESCRIPTION
Updating pre-commit hook with make. pre-commit-golang repo is no longer maintained[1]. Instead of using
unmaintained repo we can use make to run pre-commit.

[1] https://github.com/dnephin/pre-commit-golang/issues/98