### PR TITLE
Fix omitempty + default value

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -320,5 +320,5 @@ gowork: ## Generate go.work file to support our multi module repository
 
 .PHONY: operator-lint
 operator-lint: gowork ## Runs operator-lint
-	GOBIN=$(LOCALBIN) go install github.com/gibizer/operator-lint@v0.1.0
+	GOBIN=$(LOCALBIN) go install github.com/gibizer/operator-lint@v0.3.0
 	go vet -vettool=$(LOCALBIN)/operator-lint ./... ./api/...

--- a/api/bases/neutron.openstack.org_neutronapis.yaml
+++ b/api/bases/neutron.openstack.org_neutronapis.yaml
@@ -52,7 +52,6 @@ spec:
                 default: quay.io/tripleozedcentos9/openstack-neutron-server:current-tripleo
                 type: string
               customServiceConfig:
-                default: '# add your customization here'
                 description: CustomServiceConfig - customize the service config using
                   this parameter to change service defaults, or overwrite rendered
                   information using raw OpenStack config format. The content gets

--- a/api/v1beta1/neutronapi_types.go
+++ b/api/v1beta1/neutronapi_types.go
@@ -69,7 +69,7 @@ type NeutronAPISpec struct {
 
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default="quay.io/tripleozedcentos9/openstack-neutron-server:current-tripleo"
-	ContainerImage string `json:"containerImage,omitempty"`
+	ContainerImage string `json:"containerImage"`
 
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=1
@@ -85,7 +85,7 @@ type NeutronAPISpec struct {
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default={database: NeutronDatabasePassword, service: NeutronPassword}
 	// PasswordSelectors - Selectors to identify the DB and ServiceUser password from the Secret
-	PasswordSelectors PasswordSelector `json:"passwordSelectors,omitempty"`
+	PasswordSelectors PasswordSelector `json:"passwordSelectors"`
 
 	// +kubebuilder:validation:Optional
 	// NodeSelector to target subset of worker nodes running this service
@@ -99,10 +99,9 @@ type NeutronAPISpec struct {
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=false
 	// PreserveJobs - do not delete jobs after they finished e.g. to check logs
-	PreserveJobs bool `json:"preserveJobs,omitempty"`
+	PreserveJobs bool `json:"preserveJobs"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default="# add your customization here"
 	// CustomServiceConfig - customize the service config using this parameter to change service defaults,
 	// or overwrite rendered information using raw OpenStack config format. The content gets added to
 	// to /etc/<service>/<service>.conf.d directory as custom.conf file.
@@ -163,11 +162,11 @@ type PasswordSelector struct {
 	// +kubebuilder:default="NeutronDatabasePassword"
 	// Database - Selector to get the neutron database user password from the Secret
 	// TODO: not used, need change in mariadb-operator
-	Database string `json:"database,omitempty"`
+	Database string `json:"database"`
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default="NeutronPassword"
 	// Database - Selector to get the neutron service password from the Secret
-	Service string `json:"service,omitempty"`
+	Service string `json:"service"`
 }
 
 // NeutronAPIDebug defines the observed state of NeutronAPIDebug
@@ -175,15 +174,15 @@ type NeutronAPIDebug struct {
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=false
 	// DBSync enable debug
-	DBSync bool `json:"dbSync,omitempty"`
+	DBSync bool `json:"dbSync"`
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=false
 	// Bootstrap enable debug
-	Bootstrap bool `json:"bootstrap,omitempty"`
+	Bootstrap bool `json:"bootstrap"`
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=false
 	// Service enable debug
-	Service bool `json:"service,omitempty"`
+	Service bool `json:"service"`
 }
 
 // NeutronAPIStatus defines the observed state of NeutronAPI

--- a/config/crd/bases/neutron.openstack.org_neutronapis.yaml
+++ b/config/crd/bases/neutron.openstack.org_neutronapis.yaml
@@ -52,7 +52,6 @@ spec:
                 default: quay.io/tripleozedcentos9/openstack-neutron-server:current-tripleo
                 type: string
               customServiceConfig:
-                default: '# add your customization here'
                 description: CustomServiceConfig - customize the service config using
                   this parameter to change service defaults, or overwrite rendered
                   information using raw OpenStack config format. The content gets


### PR DESCRIPTION
Having a CRD field with omitempty tag with a kubebuilder default value defined can cause unexpected behavior. See
https://github.com/gibizer/operator-lint/blob/main/linters/crd/C003 for details.

So this patch remove the problematic definitions and bumps the operator-lint version to 0.3.0 that has a check to cover this.