### PR TITLE
Use new internal-DB addresses exposed by ovnclient

### DIFF
--- a/controllers/neutronapi_controller.go
+++ b/controllers/neutronapi_controller.go
@@ -832,8 +832,8 @@ func (r *NeutronAPIReconciler) generateServiceConfigMaps(
 	templateParameters["KeystoneInternalURL"] = keystoneInternalURL
 	templateParameters["KeystonePublicURL"] = keystonePublicURL
 
-	templateParameters["NBConnection"] = dbmap["NB"]
-	templateParameters["SBConnection"] = dbmap["SB"]
+	templateParameters["NBConnection"] = dbmap["internal-NB"]
+	templateParameters["SBConnection"] = dbmap["internal-SB"]
 
 	cms := []util.Template{
 		// ScriptsConfigMap

--- a/go.mod
+++ b/go.mod
@@ -11,13 +11,13 @@ require (
 	github.com/openshift/api v3.9.0+incompatible
 	github.com/openstack-k8s-operators/infra-operator/apis v0.0.0-20230203151002-5ca00e898340
 	github.com/openstack-k8s-operators/keystone-operator/api v0.0.0-20230208150008-87df8c2f32cb
-	github.com/openstack-k8s-operators/lib-common/modules/common v0.0.0-20230215134634-d31141e5bbba
+	github.com/openstack-k8s-operators/lib-common/modules/common v0.0.0-20230220103808-bd9bda2ad709
 	github.com/openstack-k8s-operators/lib-common/modules/database v0.0.0-20230215134634-d31141e5bbba
 	github.com/openstack-k8s-operators/lib-common/modules/storage v0.0.0-20230307144813-39ed0da90b23
 	github.com/openstack-k8s-operators/lib-common/modules/test v0.0.0-20230215134634-d31141e5bbba
 	github.com/openstack-k8s-operators/mariadb-operator/api v0.0.0-20230111085237-6c4718088841
 	github.com/openstack-k8s-operators/neutron-operator/api v0.0.0-20221130112258-2d20ea7691aa
-	github.com/openstack-k8s-operators/ovn-operator/api v0.0.0-20230119070807-ae18fe5d848f
+	github.com/openstack-k8s-operators/ovn-operator/api v0.0.0-20230324110832-22157b6770f3
 	go.uber.org/zap v1.24.0
 	k8s.io/api v0.26.1
 	k8s.io/apimachinery v0.26.1

--- a/go.sum
+++ b/go.sum
@@ -233,8 +233,8 @@ github.com/openstack-k8s-operators/infra-operator/apis v0.0.0-20230203151002-5ca
 github.com/openstack-k8s-operators/infra-operator/apis v0.0.0-20230203151002-5ca00e898340/go.mod h1:1eXDVJYo3+NPrAyvrDo9BTcc2W/v+b6Jw/cL7O0aAno=
 github.com/openstack-k8s-operators/keystone-operator/api v0.0.0-20230208150008-87df8c2f32cb h1:2liBXr5C9LaAM1e/CQWNY7PRwDVnPp3df9Q8lvVv5BI=
 github.com/openstack-k8s-operators/keystone-operator/api v0.0.0-20230208150008-87df8c2f32cb/go.mod h1:gr1gxe+nRHt1UNzc7D5jTXN6auvufTzhqdVsubQsLDc=
-github.com/openstack-k8s-operators/lib-common/modules/common v0.0.0-20230215134634-d31141e5bbba h1:IIM8K8j1mOJx16Epwrau6bx5DU2rxj8NGTjjxrjlF4I=
-github.com/openstack-k8s-operators/lib-common/modules/common v0.0.0-20230215134634-d31141e5bbba/go.mod h1:+EDQmWZRA8ruHnWPcw9s/el3UMi6u4EZkcSe7dCQ50k=
+github.com/openstack-k8s-operators/lib-common/modules/common v0.0.0-20230220103808-bd9bda2ad709 h1:g3sO7qyvAz3ltQG+I81bsM3SwrI8ILYPv+s6bWT3tLU=
+github.com/openstack-k8s-operators/lib-common/modules/common v0.0.0-20230220103808-bd9bda2ad709/go.mod h1:wDUzrnAhtC0O99PYR8qQWQoGJzVQwGnfGepKzExCVk8=
 github.com/openstack-k8s-operators/lib-common/modules/database v0.0.0-20230215134634-d31141e5bbba h1:KWjeUGGzfZ7u2cQJNdzpg4UIghURS241up0FOyssLxM=
 github.com/openstack-k8s-operators/lib-common/modules/database v0.0.0-20230215134634-d31141e5bbba/go.mod h1:rONM/XgvFs6putDIxRHNv9/CTGh2afAvJM5wRP2OywY=
 github.com/openstack-k8s-operators/lib-common/modules/openstack v0.0.0-20230208113903-f7b52e2a2ccb h1:J4/Q3K0zkdUwtTRcXaxvoMK+ZgggxVtNjzEvqBu/siQ=
@@ -247,8 +247,8 @@ github.com/openstack-k8s-operators/mariadb-operator/api v0.0.0-20230111085237-6c
 github.com/openstack-k8s-operators/mariadb-operator/api v0.0.0-20230111085237-6c4718088841/go.mod h1:HiEKXmDSJ6Gl+pN7kK5CX1sgOjrxybux4Ob5pdUim1M=
 github.com/openstack-k8s-operators/openstack-operator/apis v0.0.0-20230110193440-5da705fb9753 h1:12zWkfDbuXLn2hedwXY997kkw9Zpb+nrmduKAUzuSm8=
 github.com/openstack-k8s-operators/openstack-operator/apis v0.0.0-20230110193440-5da705fb9753/go.mod h1:tzWqG4XeD4Q6QLAjtX3GgW6KYNenj0U+FNxn+qDqImo=
-github.com/openstack-k8s-operators/ovn-operator/api v0.0.0-20230119070807-ae18fe5d848f h1:OI5yMzINpsINJKsNE1noHK2DGAeuE4fxKflmXiIboVs=
-github.com/openstack-k8s-operators/ovn-operator/api v0.0.0-20230119070807-ae18fe5d848f/go.mod h1:GUQ966Lr4rg+XnIYlYO+YX+rMg7OmNzYYvDk4uSIQVU=
+github.com/openstack-k8s-operators/ovn-operator/api v0.0.0-20230324110832-22157b6770f3 h1:7cy1GXiMG1BBkxaj+3nGIwcGDOTcMrEi+8IJ9aHe1b4=
+github.com/openstack-k8s-operators/ovn-operator/api v0.0.0-20230324110832-22157b6770f3/go.mod h1:vsHUVpBJYuphy753SLEKvNKX2FgtauSrxsxM3CeuDkM=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/test/functional/base_test.go
+++ b/test/functional/base_test.go
@@ -334,7 +334,7 @@ func CreateOVNDBClusters(namespace string) []types.NamespacedName {
 		// the Status field needs to be written via a separate client
 		ovndbcluster = GetOVNDBCluster(name)
 		ovndbcluster.Status = ovnv1.OVNDBClusterStatus{
-			DBAddress: dbaddr,
+			InternalDBAddress: dbaddr,
 		}
 		Expect(k8sClient.Status().Update(ctx, ovndbcluster.DeepCopy())).Should(Succeed())
 		dbs = append(dbs, name)

--- a/test/functional/neutronapi_controller_test.go
+++ b/test/functional/neutronapi_controller_test.go
@@ -291,7 +291,7 @@ var _ = Describe("NeutronAPI controller", func() {
 			for _, db := range dbs {
 				ovndb := GetOVNDBCluster(db)
 				Expect(th.GetConfigMap(configataCM).Data["neutron.conf"]).Should(
-					ContainSubstring("ovn_%s_connection = %s", strings.ToLower(string(ovndb.Spec.DBType)), ovndb.Status.DBAddress))
+					ContainSubstring("ovn_%s_connection = %s", strings.ToLower(string(ovndb.Spec.DBType)), ovndb.Status.InternalDBAddress))
 			}
 
 			th.ExpectCondition(


### PR DESCRIPTION
With patch [1] ovnclient will expose internal (POD network) and edpm (external network). This patch adopts neutron-operator for that change.

Requires: https://github.com/openstack-k8s-operators/ovn-operator/pull/32

[1] https://github.com/openstack-k8s-operators/ovn-operator/pull/32