### PR TITLE
Add golangci-lint config

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,17 @@
+linters:
+  # Enable specific linter
+  # https://golangci-lint.run/usage/linters/#enabled-by-default
+  enable:
+    - errorlint
+    - revive
+    - gofmt
+    - govet
+linters-settings:
+  revive:
+    rules:
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unused-parameter
+      - name: unused-parameter
+        severity: warning
+        disabled: true
+run:
+  timeout: 5m


### PR DESCRIPTION
* Bumps the timeout from 1min to 5min to allow slower CI runs to pass
* Enabled common set of linter