### PR TITLE
Remove install_yamls dependency for kuttl tests

### DIFF
--- a/test/kuttl/common/cleanup-neutron.yaml
+++ b/test/kuttl/common/cleanup-neutron.yaml
@@ -2,5 +2,5 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   - script: |
-      PWD=$INSTALL_YAMLS
-      make -C $INSTALL_YAMLS neutron_deploy_cleanup
+      oc kustomize deploy | oc delete -n openstack -f -
+      rm deploy/neutron_v1beta1_neutronapi.yaml

--- a/test/kuttl/common/deploy_neutron.yaml
+++ b/test/kuttl/common/deploy_neutron.yaml
@@ -1,6 +1,0 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestStep
-commands:
-  - script: |
-      PWD=$INSTALL_YAMLS
-      make -C $INSTALL_YAMLS neutron_deploy

--- a/test/kuttl/tests/neutron_scale/01-deploy-neutron.yaml
+++ b/test/kuttl/tests/neutron_scale/01-deploy-neutron.yaml
@@ -1,1 +1,6 @@
-../../common/deploy_neutron.yaml
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: |
+      cp ../../../../config/samples/neutron_v1beta1_neutronapi.yaml deploy
+      oc kustomize deploy | oc apply -n openstack -f -

--- a/test/kuttl/tests/neutron_scale/deploy/kustomization.yaml
+++ b/test/kuttl/tests/neutron_scale/deploy/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ./neutron_v1beta1_neutronapi.yaml
+patches:
+- patch: |-
+    - op: replace
+      path: /spec/secret
+      value: osp-secret
+  target:
+    kind: NeutronAPI


### PR DESCRIPTION
Instead of using install_yamls targets for deploying and cleaning up
neutron, use the CR sample from config/samples. This removes a possible
circular dependency issue when using install_yamls to run the jobs and
to run some test steps.
