### PR TITLE
Replace TripleO images by TCIB images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -333,7 +333,7 @@ operator-lint: gowork ## Runs operator-lint
 # $oc delete -n openstack mutatingwebhookconfiguration/mneutronapi.kb.io
 SKIP_CERT ?=false
 .PHONY: run-with-webhook
-run-with-webhook: export NEUTRON_API_IMAGE_URL_DEFAULT=quay.io/tripleozedcentos9/openstack-neutron-server:current-tripleo
+run-with-webhook: export NEUTRON_API_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-neutron-server:current-podified
 run-with-webhook: manifests generate fmt vet ## Run a controller from your host.
 	/bin/bash hack/configure_local_webhook.sh
 	go run ./main.go

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ kind: NeutronAPI
 metadata:
   name: neutron
 spec:
-  containerImage: quay.io/tripleowallabycentos9/openstack-neutron-server:current-tripleo
+  containerImage: quay.io/tripleowallabycentos9/openstack-neutron-server:current-podified
   databaseInstance: openstack
   secret: neutron-secret
 ```
@@ -208,7 +208,7 @@ spec:
     dbSync: false
     service: false
   preserveJobs: false
-  containerImage: quay.io/tripleozedcentos9/openstack-neutron-server:current-tripleo
+  containerImage: quay.io/podified-antelope-centos9/openstack-neutron-server:current-podified
   replicas: 1
   secret: neutron-secret
   extraMounts:

--- a/config/default/manager_default_images.yaml
+++ b/config/default/manager_default_images.yaml
@@ -12,4 +12,4 @@ spec:
       - name: manager
         env:
         - name: NEUTRON_API_IMAGE_URL_DEFAULT
-          value: quay.io/tripleozedcentos9/openstack-neutron-server:current-tripleo
+          value: quay.io/podified-antelope-centos9/openstack-neutron-server:current-podified

--- a/config/samples/neutron_v1beta1_neutronapi.yaml
+++ b/config/samples/neutron_v1beta1_neutronapi.yaml
@@ -15,6 +15,6 @@ spec:
     dbSync: false
     service: false
   preserveJobs: false
-  containerImage: quay.io/tripleozedcentos9/openstack-neutron-server:current-tripleo
+  containerImage: quay.io/podified-antelope-centos9/openstack-neutron-server:current-podified
   replicas: 1
   secret: neutron-secret

--- a/test/kuttl/common/assert_sample_deployment.yaml
+++ b/test/kuttl/common/assert_sample_deployment.yaml
@@ -15,7 +15,7 @@ metadata:
   name: neutron
   namespace: openstack
 spec:
-  containerImage: quay.io/tripleozedcentos9/openstack-neutron-server:current-tripleo
+  containerImage: quay.io/podified-antelope-centos9/openstack-neutron-server:current-podified
   customServiceConfig: |
     [DEFAULT]
     debug = true
@@ -78,7 +78,7 @@ spec:
         - /usr/local/bin/kolla_set_configs && /usr/local/bin/kolla_start
         command:
         - /bin/bash
-        image: quay.io/tripleozedcentos9/openstack-neutron-server:current-tripleo
+        image: quay.io/podified-antelope-centos9/openstack-neutron-server:current-podified
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -133,7 +133,7 @@ spec:
             secretKeyRef:
               key: transport_url
               name: rabbitmq-transport-url-neutron-neutron-transport
-        image: quay.io/tripleozedcentos9/openstack-neutron-server:current-tripleo
+        image: quay.io/podified-antelope-centos9/openstack-neutron-server:current-podified
         imagePullPolicy: IfNotPresent
         name: init
         resources: {}


### PR DESCRIPTION
We imported container build tools from TripleO as TCIB[1]. Now we are retiring TripleO and should complete the migration.

[1] https://github.com/openstack-k8s-operators/tcib