### PR TITLE
Add local templates export to MakeFile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,6 +128,7 @@ build: generate fmt vet ## Build manager binary.
 
 .PHONY: run
 run: export ENABLE_WEBHOOKS?=false
+run: export OPERATOR_TEMPLATES=./templates/
 run: manifests generate fmt vet ## Run a controller from your host.
 	/bin/bash hack/clean_local_webhook.sh
 	go run ./main.go

--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ build: generate fmt vet ## Build manager binary.
 
 .PHONY: run
 run: export ENABLE_WEBHOOKS?=false
-run: export OPERATOR_TEMPLATES=./templates/
+run: export OPERATOR_TEMPLATES?=./templates/
 run: manifests generate fmt vet ## Run a controller from your host.
 	/bin/bash hack/clean_local_webhook.sh
 	go run ./main.go


### PR DESCRIPTION
This is required when running operator locally and has been added to some other operators already such as [1]

[1] https://github.com/openstack-k8s-operators/glance-operator/blob/master/Makefile#L147