### PR TITLE
Ctrl manager labels for webhooks and logging

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -2,7 +2,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    control-plane: neutron-controller-manager
+    control-plane: controller-manager
+    openstack.org/operator-name: neutron
   name: system
 ---
 apiVersion: apps/v1
@@ -11,22 +12,20 @@ metadata:
   name: controller-manager
   namespace: system
   labels:
-    control-plane: neutron-controller-manager
-    app.kubernetes.io/name: neutron-operator
-    app.kubernetes.io/component: neutron
+    control-plane: controller-manager
+    openstack.org/operator-name: neutron
 spec:
   selector:
     matchLabels:
-      control-plane: neutron-controller-manager
+      openstack.org/operator-name: neutron
   replicas: 1
   template:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        control-plane: neutron-controller-manager
-        app.kubernetes.io/name: neutron-operator
-        app.kubernetes.io/component: neutron
+        control-plane: controller-manager
+        openstack.org/operator-name: neutron
     spec:
       securityContext:
         runAsNonRoot: true

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -4,7 +4,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    control-plane: neutron-controller-manager
+    control-plane: controller-manager
   name: controller-manager-metrics-monitor
   namespace: system
 spec:
@@ -17,4 +17,4 @@ spec:
         insecureSkipVerify: true
   selector:
     matchLabels:
-      control-plane: neutron-controller-manager
+      openstack.org/operator-name: neutron

--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    control-plane: neutron-controller-manager
+    control-plane: controller-manager
   name: controller-manager-metrics-service
   namespace: system
 spec:
@@ -12,4 +12,4 @@ spec:
     protocol: TCP
     targetPort: https
   selector:
-    control-plane: neutron-controller-manager
+    openstack.org/operator-name: neutron

--- a/config/webhook/service.yaml
+++ b/config/webhook/service.yaml
@@ -17,4 +17,4 @@ spec:
       protocol: TCP
       targetPort: 9443
   selector:
-    control-plane: neutron-controller-manager
+    openstack.org/operator-name: neutron


### PR DESCRIPTION
Consistent label with ovn/ovs operator[1][2], and
remove other labels(added as part of[3]) which are not needed now with these new labels.

[1] https://github.com/openstack-k8s-operators/ovs-operator/pull/109
[2] https://github.com/openstack-k8s-operators/ovn-operator/pull/45
[3] https://github.com/openstack-k8s-operators/neutron-operator/pull/102