### PR TITLE
Remove unused constant for admin endpoint

### DIFF
--- a/pkg/neutronapi/const.go
+++ b/pkg/neutronapi/const.go
@@ -18,8 +18,6 @@ const (
 	// Database -
 	Database = "neutron"
 
-	// NeutronAdminPort -
-	NeutronAdminPort int32 = 9696
 	// NeutronPublicPort -
 	NeutronPublicPort int32 = 9696
 	// NeutronInternalPort -


### PR DESCRIPTION
The constant has not been used since we stopped creating admin endpoint.