### PR TITLE
Add GINKGO_ARGS env var to test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ PROC_CMD = --procs ${PROCS}
 
 .PHONY: test
 test: manifests generate fmt vet envtest ginkgo ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) -v debug --bin-dir $(LOCALBIN) use $(ENVTEST_K8S_VERSION) -p path)" $(GINKGO) --trace --cover --coverpkg=../../pkg/neutronapi,../../controllers,../../api/v1beta1 --coverprofile cover.out --covermode=atomic --randomize-all ${PROC_CMD} ./test/...
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) -v debug --bin-dir $(LOCALBIN) use $(ENVTEST_K8S_VERSION) -p path)" $(GINKGO) --trace --cover --coverpkg=../../pkg/neutronapi,../../controllers,../../api/v1beta1 --coverprofile cover.out --covermode=atomic --randomize-all ${PROC_CMD} $(GINKGO_ARGS) ./test/...
 
 ##@ Build
 .PHONY: build


### PR DESCRIPTION
With this change you can pass arbitrary parameters to the ginkgo test executor via the make target.

E.g. if you want to run only a subset of test sequentially failing on the first error then you can do that with:

make test GINKGO_ARGS="--focus 'should create a ConfigMap for neutron.conf with' --fail-fast  --procs 1"

Taken from https://github.com/openstack-k8s-operators/nova-operator/pull/303