### PR TITLE
Update renovate.json to latest updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,5 @@
 {
-  "timezone": "America/New_York",
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
+"extends": [
     "config:base"
   ],
   "dependencyDashboard": true,
@@ -16,29 +14,32 @@
   ],
   "packageRules": [
     {
-      "matchPackageNames": ["go"],
+      "matchPackageNames": ["github.com/openstack-k8s-operators/neutron-operator/api"],
       "enabled": false
     },
     {
       "groupName": "openstack-k8s-operators",
-      "matchPackagePatterns": ["^github.com/openstack-k8s-operators"],
-      "enabled": true
+      "matchPackagePrefixes": ["github.com/openstack-k8s-operators"],
+      "excludePackageNames": ["github.com/openstack-k8s-operators/neutron-operator/api"],
+      "schedule": [
+        "every weekend"
+      ]
     },
     {
       "groupName": "k8s.io",
-      "matchPackagePatterns": ["^k8s.io", "^sigs.k8s.io"],
-      "allowedVersions": "< 1.0.0",
-      "enabled": true
-    },
-    {
-      "groupName": "misc",
-      "matchPackagePatterns": ["^github.com/operator-framework/api", "^github.com/ghodss", "^github.com/go-logr/logr", "^github.com/imdario/mergo", "^go.uber.org/zap"],
-      "enabled": true
+      "matchPackagePrefixes": [
+        "k8s.io",
+        "sigs.k8s.io"
+      ],
+      "schedule": [
+        "every weekend"
+      ],
+      "allowedVersions": "< 1.0.0"
     }
   ],
   "postUpgradeTasks": {
-    "commands": ["go mod tidy", "make manifests generate"],
-    "fileFilters": ["go.mod", "go.sum", "**/*.go", "**/*.yaml"],
+    "commands": ["make gowork", "make tidy", "make manifests generate"],
+    "fileFilters": ["**/go.mod", "**/go.sum", "**/*.go", "**/*.yaml"],
     "executionMode": "update"
   }
 }


### PR DESCRIPTION
renovate bot was not running yet and is being enabled with [1], renovate.json was missing some recent fixes that is done in other operators. This patch syncs it.

[1] https://github.com/openstack-k8s-operators/openstack-k8s-operators-ci/pull/83