### PR TITLE
Change master branch to main

### DIFF
--- a/.github/workflows/build-neutron-operator.yaml
+++ b/.github/workflows/build-neutron-operator.yaml
@@ -35,8 +35,8 @@ jobs:
       id: branch-name
       uses: tj-actions/branch-names@v5
 
-    - name: Set latest tag for non master branch
-      if: "${{ steps.branch-name.outputs.current_branch != 'master' }}"
+    - name: Set latest tag for non main branch
+      if: "${{ steps.branch-name.outputs.current_branch != 'main' }}"
       run: |
         echo "latesttag=${{ steps.branch-name.outputs.current_branch }}-latest" >> $GITHUB_ENV
 
@@ -109,8 +109,8 @@ jobs:
       id: branch-name
       uses: tj-actions/branch-names@v5
 
-    - name: Set latest tag for non master branch
-      if: "${{ steps.branch-name.outputs.current_branch != 'master' }}"
+    - name: Set latest tag for non main branch
+      if: "${{ steps.branch-name.outputs.current_branch != 'main' }}"
       run: |
         echo "latesttag=${{ steps.branch-name.outputs.current_branch }}-latest" >> $GITHUB_ENV
 
@@ -146,8 +146,8 @@ jobs:
       id: branch-name
       uses: tj-actions/branch-names@v5
 
-    - name: Set latest tag for non master branch
-      if: "${{ steps.branch-name.outputs.current_branch != 'master' }}"
+    - name: Set latest tag for non main branch
+      if: "${{ steps.branch-name.outputs.current_branch != 'main' }}"
       run: |
         echo "latesttag=${{ steps.branch-name.outputs.current_branch }}-latest" >> $GITHUB_ENV
 


### PR DESCRIPTION
In line with Red Hat's commitment to use inclusive language in our products. This change renames the default branch from master to main.