### PR TITLE
limit neutron server workers by default

### DIFF
--- a/templates/neutronapi/config/neutron.conf
+++ b/templates/neutronapi/config/neutron.conf
@@ -3,11 +3,11 @@ auth_strategy = keystone
 core_plugin = neutron.plugins.ml2.plugin.Ml2Plugin
 service_plugins = qos,ovn-router,trunk,segments,port_forwarding,log
 dns_domain = openstackgate.local
-
 dhcp_agent_notification = false
-
 notify_nova_on_port_status_changes = true
 notify_nova_on_port_data_changes = true
+api_workers = 2
+rpc_workers = 1
 
 [ml2]
 mechanism_drivers = ovn


### PR DESCRIPTION
This change limits the neutorn server to 2 api workers
and 1 RPC worker by default.
Closes: #164 