### PR TITLE
Remove HostPath volume mounts

### DIFF
--- a/pkg/neutronapi/volumes.go
+++ b/pkg/neutronapi/volumes.go
@@ -43,22 +43,6 @@ func GetAPIVolumes(name string, extraVol []neutronv1beta1.NeutronExtraVolMounts,
 
 	res := []corev1.Volume{
 		{
-			Name: "etc-machine-id",
-			VolumeSource: corev1.VolumeSource{
-				HostPath: &corev1.HostPathVolumeSource{
-					Path: "/etc/machine-id",
-				},
-			},
-		},
-		{
-			Name: "etc-localtime",
-			VolumeSource: corev1.VolumeSource{
-				HostPath: &corev1.HostPathVolumeSource{
-					Path: "/etc/localtime",
-				},
-			},
-		},
-		{
 			Name: "scripts",
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
@@ -99,16 +83,6 @@ func GetAPIVolumes(name string, extraVol []neutronv1beta1.NeutronExtraVolMounts,
 // GetAPIVolumeMounts - Neutron API VolumeMounts
 func GetAPIVolumeMounts(extraVol []neutronv1beta1.NeutronExtraVolMounts, svc []storage.PropagationType) []corev1.VolumeMount {
 	res := []corev1.VolumeMount{
-		{
-			Name:      "etc-machine-id",
-			MountPath: "/etc/machine-id",
-			ReadOnly:  true,
-		},
-		{
-			Name:      "etc-localtime",
-			MountPath: "/etc/localtime",
-			ReadOnly:  true,
-		},
 		{
 			Name:      "scripts",
 			MountPath: "/usr/local/bin/container-scripts",

--- a/test/functional/neutronapi_controller_test.go
+++ b/test/functional/neutronapi_controller_test.go
@@ -429,13 +429,13 @@ var _ = Describe("NeutronAPI controller", func() {
 				},
 			)
 			Expect(int(*deployment.Spec.Replicas)).To(Equal(1))
-			Expect(deployment.Spec.Template.Spec.Volumes).To(HaveLen(5))
+			Expect(deployment.Spec.Template.Spec.Volumes).To(HaveLen(3))
 			Expect(deployment.Spec.Template.Spec.Containers).To(HaveLen(1))
 
 			container := deployment.Spec.Template.Spec.Containers[0]
 			Expect(container.LivenessProbe.HTTPGet.Port.IntVal).To(Equal(int32(9696)))
 			Expect(container.ReadinessProbe.HTTPGet.Port.IntVal).To(Equal(int32(9696)))
-			Expect(container.VolumeMounts).To(HaveLen(4))
+			Expect(container.VolumeMounts).To(HaveLen(2))
 			Expect(container.Image).To(Equal("test-neutron-container-image"))
 
 			Expect(container.LivenessProbe.HTTPGet.Port.IntVal).To(Equal(int32(9696)))

--- a/test/kuttl/common/assert_sample_deployment.yaml
+++ b/test/kuttl/common/assert_sample_deployment.yaml
@@ -157,7 +157,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
-    openshift.io/scc: privileged
+    openshift.io/scc: anyuid
   labels:
     service: neutron
 ---


### PR DESCRIPTION
Timezone can be configured by TZ environment and this is more flexible. (For example users can configure different timezone for pods and platform.)

Also, mounting machine-id does not guarantee unique id in pods because we do not strictly prohibit running multiple pods in the same node.