### PR TITLE
Include Ihar in network-approvers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -6,6 +6,7 @@ aliases:
   - viroel
   network-approvers:
   - beagles
+  - booxter
   - karelyatin
   - slawqo
   openstack-approvers:


### PR DESCRIPTION
He is still able to approve the PRs but
seems that's happening as he is part of the
admin group[1] for this repo.

[1] https://github.com/orgs/openstack-k8s-operators/teams/network