### PR TITLE
Set OPERATOR_TEMPLATES for tests in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ PROC_CMD = --procs ${PROCS}
 
 .PHONY: test
 test: manifests generate fmt vet envtest ginkgo ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) -v debug --bin-dir $(LOCALBIN) use $(ENVTEST_K8S_VERSION) -p path)" $(GINKGO) --trace --cover --coverpkg=../../pkg/neutronapi,../../controllers,../../api/v1beta1 --coverprofile cover.out --covermode=atomic --randomize-all ${PROC_CMD} $(GINKGO_ARGS) ./test/...
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) -v debug --bin-dir $(LOCALBIN) use $(ENVTEST_K8S_VERSION) -p path)" OPERATOR_TEMPLATES="$(shell pwd)/templates" $(GINKGO) --trace --cover --coverpkg=../../pkg/neutronapi,../../controllers,../../api/v1beta1 --coverprofile cover.out --covermode=atomic --randomize-all ${PROC_CMD} $(GINKGO_ARGS) ./test/...
 
 ##@ Build
 .PHONY: build
@@ -128,7 +128,6 @@ build: generate fmt vet ## Build manager binary.
 
 .PHONY: run
 run: export ENABLE_WEBHOOKS?=false
-run: export OPERATOR_TEMPLATES?=./templates/
 run: manifests generate fmt vet ## Run a controller from your host.
 	/bin/bash hack/clean_local_webhook.sh
 	go run ./main.go

--- a/test/functional/neutronapi_controller_test.go
+++ b/test/functional/neutronapi_controller_test.go
@@ -18,7 +18,6 @@ package functional_test
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/google/uuid"
@@ -48,11 +47,6 @@ var _ = Describe("NeutronAPI controller", func() {
 		// We still request the delete of the Namespace to properly cleanup if
 		// we run the test in an existing cluster.
 		DeferCleanup(th.DeleteNamespace, namespace)
-		// lib-common uses OPERATOR_TEMPLATES env var to locate the "templates"
-		// directory of the operator. We need to set them otherwise lib-common
-		// will fail to generate the ConfigMap as it does not find common.sh
-		err := os.Setenv("OPERATOR_TEMPLATES", "../../templates")
-		Expect(err).NotTo(HaveOccurred())
 
 		name := fmt.Sprintf("neutron-%s", uuid.New().String())
 		apiTransportURLName = types.NamespacedName{


### PR DESCRIPTION
It would be more clean setting in Makefile
instead of hard coding relative path in the
test code.

Also drop OPERATOR_TEMPLATES default from run
target as it's no longer needed since [1].

[1] https://github.com/openstack-k8s-operators/lib-common/pull/200