### PR TITLE
Change kuttl tests to run in any namespace

### DIFF
--- a/kuttl-test.yaml
+++ b/kuttl-test.yaml
@@ -16,9 +16,9 @@
 
 apiVersion: kuttl.dev/v1beta1
 kind: TestSuite
+namespace: neutron-kuttl-tests
 reportFormat: JSON
 reportName: kuttl-test-neutron
-namespace: openstack
 timeout: 180
 parallel: 1
 suppress:

--- a/test/kuttl/common/assert_sample_deployment.yaml
+++ b/test/kuttl/common/assert_sample_deployment.yaml
@@ -13,7 +13,6 @@ metadata:
   finalizers:
   - NeutronAPI
   name: neutron
-  namespace: openstack
 spec:
   containerImage: quay.io/podified-antelope-centos9/openstack-neutron-server:current-podified
   customServiceConfig: |
@@ -42,7 +41,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: neutron
-  namespace: openstack
 spec:
   progressDeadlineSeconds: 600
   replicas: 1
@@ -168,7 +166,6 @@ metadata:
     internal: "true"
     service: neutron
   name: neutron-internal
-  namespace: openstack
 spec:
   internalTrafficPolicy: Cluster
   ipFamilies:
@@ -191,7 +188,6 @@ metadata:
     public: "true"
     service: neutron
   name: neutron-public
-  namespace: openstack
 spec:
   internalTrafficPolicy: Cluster
   ipFamilies:
@@ -214,7 +210,6 @@ metadata:
   labels:
     public: "true"
     service: neutron
-  namespace: openstack
 spec:
   port:
     targetPort: neutron-public
@@ -226,7 +221,6 @@ apiVersion: keystone.openstack.org/v1beta1
 kind: KeystoneEndpoint
 metadata:
   name: neutron
-  namespace: openstack
   ownerReferences:
   - apiVersion: neutron.openstack.org/v1beta1
     blockOwnerDeletion: true
@@ -239,12 +233,11 @@ metadata:
 # the two endpoints are defined and their addresses follow the default pattern
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-namespaced: true
 commands:
   - script: |
       template='{{.spec.endpoints.internal}}{{":"}}{{.spec.endpoints.public}}{{"\n"}}'
-      regex="http:\/\/neutron-internal.openstack.*:http:\/\/neutron-public.openstack.*"
-      apiEndpoints=$(oc get -n openstack KeystoneEndpoint neutron -o go-template="$template")
+      regex="http:\/\/neutron-internal.$NAMESPACE.*:http:\/\/neutron-public.$NAMESPACE.*"
+      apiEndpoints=$(oc get -n $NAMESPACE KeystoneEndpoint neutron -o go-template="$template")
       matches=$(echo "$apiEndpoints" | sed -e "s?$regex??")
       if [[ -z "$matches" ]]; then
         exit 0

--- a/test/kuttl/common/cleanup-neutron.yaml
+++ b/test/kuttl/common/cleanup-neutron.yaml
@@ -2,5 +2,5 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   - script: |
-      oc kustomize deploy | oc delete -n openstack -f -
+      oc kustomize deploy | oc delete -n $NAMESPACE -f -
       rm deploy/neutron_v1beta1_neutronapi.yaml

--- a/test/kuttl/common/errors_cleanup_neutron.yaml
+++ b/test/kuttl/common/errors_cleanup_neutron.yaml
@@ -13,13 +13,11 @@ metadata:
   finalizers:
   - NeutronAPI
   name: neutron
-  namespace: openstack
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: neutron
-  namespace: openstack
 ---
 # the openshift annotations can't be checked through the deployment above
 apiVersion: v1
@@ -37,7 +35,6 @@ metadata:
     internal: "true"
     service: neutron
   name: neutron-internal
-  namespace: openstack
 ---
 apiVersion: v1
 kind: Service
@@ -46,7 +43,6 @@ metadata:
     public: "true"
     service: neutron
   name: neutron-public
-  namespace: openstack
 ---
 apiVersion: route.openshift.io/v1
 kind: Route
@@ -55,4 +51,3 @@ metadata:
   labels:
     public: "true"
     service: neutron
-  namespace: openstack

--- a/test/kuttl/tests/neutron_scale/01-deploy-neutron.yaml
+++ b/test/kuttl/tests/neutron_scale/01-deploy-neutron.yaml
@@ -3,4 +3,4 @@ kind: TestStep
 commands:
   - script: |
       cp ../../../../config/samples/neutron_v1beta1_neutronapi.yaml deploy
-      oc kustomize deploy | oc apply -n openstack -f -
+      oc kustomize deploy | oc apply -n $NAMESPACE -f -

--- a/test/kuttl/tests/neutron_scale/02-assert.yaml
+++ b/test/kuttl/tests/neutron_scale/02-assert.yaml
@@ -11,7 +11,6 @@ metadata:
   finalizers:
   - NeutronAPI
   name: neutron
-  namespace: openstack
 spec:
   replicas: 3
 status:

--- a/test/kuttl/tests/neutron_scale/02-scale-neutronapi.yaml
+++ b/test/kuttl/tests/neutron_scale/02-scale-neutronapi.yaml
@@ -2,4 +2,4 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   - script: |
-      oc patch neutronapi -n openstack neutron --type='json' -p='[{"op": "replace", "path": "/spec/replicas", "value":3}]'
+      oc patch neutronapi -n $NAMESPACE neutron --type='json' -p='[{"op": "replace", "path": "/spec/replicas", "value":3}]'

--- a/test/kuttl/tests/neutron_scale/03-assert.yaml
+++ b/test/kuttl/tests/neutron_scale/03-assert.yaml
@@ -11,7 +11,6 @@ metadata:
   finalizers:
   - NeutronAPI
   name: neutron
-  namespace: openstack
 spec:
   replicas: 1
 status:
@@ -21,7 +20,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: neutron
-  namespace: openstack
 spec:
   replicas: 1
 status:

--- a/test/kuttl/tests/neutron_scale/03-scale-down-neutronapi.yaml
+++ b/test/kuttl/tests/neutron_scale/03-scale-down-neutronapi.yaml
@@ -2,4 +2,4 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   - script: |
-      oc patch neutronapi -n openstack neutron --type='json' -p='[{"op": "replace", "path": "/spec/replicas", "value":1}]'
+      oc patch neutronapi -n $NAMESPACE neutron --type='json' -p='[{"op": "replace", "path": "/spec/replicas", "value":1}]'

--- a/test/kuttl/tests/neutron_scale/04-assert.yaml
+++ b/test/kuttl/tests/neutron_scale/04-assert.yaml
@@ -11,7 +11,6 @@ metadata:
   finalizers:
   - NeutronAPI
   name: neutron
-  namespace: openstack
 spec:
   replicas: 0
 ---

--- a/test/kuttl/tests/neutron_scale/04-scale-down-zero-neutronapi.yaml
+++ b/test/kuttl/tests/neutron_scale/04-scale-down-zero-neutronapi.yaml
@@ -2,4 +2,4 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   - script: |
-      oc patch neutronapi -n openstack neutron --type='json' -p='[{"op": "replace", "path": "/spec/replicas", "value":0}]'
+      oc patch neutronapi -n $NAMESPACE neutron --type='json' -p='[{"op": "replace", "path": "/spec/replicas", "value":0}]'

--- a/test/kuttl/tests/neutron_scale/deploy/kustomization.yaml
+++ b/test/kuttl/tests/neutron_scale/deploy/kustomization.yaml
@@ -7,5 +7,7 @@ patches:
     - op: replace
       path: /spec/secret
       value: osp-secret
+    - op: remove
+      path: /metadata/namespace
   target:
     kind: NeutronAPI


### PR DESCRIPTION
Modify the kuttl tests so that they can run in any namespace, not just
in the openstack one. This requires removing any mention of the
namespace in the asserts and using the $NAMESPACE variable in scripts
instead of the namespace name.

Needs https://github.com/openstack-k8s-operators/install_yamls/pull/458 to be merged for kuttl job in CI to pass.
