### PR TITLE
Create config Secret for DHCP agent

### DIFF
--- a/pkg/neutronapi/const.go
+++ b/pkg/neutronapi/const.go
@@ -31,6 +31,9 @@ const (
 
 	// Key in external Secret for Neutron SR-IOV Agent with agent config
 	NeutronSriovAgentSecretKey = "10-neutron-sriov.conf"
+
+	// Key in external Secret for Neutron DHCP Agent with agent config
+	NeutronDhcpAgentSecretKey = "10-neutron-dhcp.conf"
 )
 
 // DbsyncPropagation keeps track of the DBSync Service Propagation Type

--- a/templates/dhcp-agent.conf
+++ b/templates/dhcp-agent.conf
@@ -1,0 +1,2 @@
+[DEFAULT]
+transport_url = {{ .transportURL }}

--- a/test/functional/neutronapi_controller_test.go
+++ b/test/functional/neutronapi_controller_test.go
@@ -198,6 +198,27 @@ var _ = Describe("NeutronAPI controller", func() {
 				g.Expect(NeutronAPI.Status.Hash[externalSriovAgentSecret.Name]).NotTo(BeEmpty())
 			}, timeout, interval).Should(Succeed())
 		})
+
+		It("should create an external DHCP Agent Secret with expected transport_url set", func() {
+			externalDhcpAgentSecret := types.NamespacedName{
+				Namespace: neutronAPIName.Namespace,
+				Name:      fmt.Sprintf("%s-dhcp-agent-neutron-config", neutronAPIName.Name),
+			}
+
+			Eventually(func() corev1.Secret {
+				return th.GetSecret(externalDhcpAgentSecret)
+			}, timeout, interval).ShouldNot(BeNil())
+
+			transportURL := "rabbit://user@svc:1234"
+
+			Expect(string(th.GetSecret(externalDhcpAgentSecret).Data[neutronapi.NeutronDhcpAgentSecretKey])).Should(
+				ContainSubstring("transport_url = %s", transportURL))
+
+			Eventually(func(g Gomega) {
+				NeutronAPI := GetNeutronAPI(neutronAPIName)
+				g.Expect(NeutronAPI.Status.Hash[externalDhcpAgentSecret.Name]).NotTo(BeEmpty())
+			}, timeout, interval).Should(Succeed())
+		})
 	})
 
 	When("OVNDBCluster instance is not available", func() {


### PR DESCRIPTION
The config is (right now) exactly the same as for sriov agent. But we still want to keep the secrets separated, if nothing else - to keep key names and secret names meaningful and explicit.