### PR TITLE
Run neutronapi / db-sync as neutron:neutron

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -204,7 +204,7 @@ rules:
   - security.openshift.io
   resourceNames:
   - anyuid
-  - privileged
+  - hostmount-anyuid
   resources:
   - securitycontextconstraints
   verbs:

--- a/controllers/neutronapi_controller.go
+++ b/controllers/neutronapi_controller.go
@@ -86,7 +86,7 @@ type NeutronAPIReconciler struct {
 // +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=roles,verbs=get;list;watch;create;update
 // +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=rolebindings,verbs=get;list;watch;create;update
 // service account permissions that are needed to grant permission to the above
-// +kubebuilder:rbac:groups="security.openshift.io",resourceNames=anyuid;privileged,resources=securitycontextconstraints,verbs=use
+// +kubebuilder:rbac:groups="security.openshift.io",resourceNames=anyuid;hostmount-anyuid,resources=securitycontextconstraints,verbs=use
 // +kubebuilder:rbac:groups="",resources=pods,verbs=create;delete;get;list;patch;update;watch
 
 // Reconcile - neutron api
@@ -611,7 +611,7 @@ func (r *NeutronAPIReconciler) reconcileNormal(ctx context.Context, instance *ne
 	rbacRules := []rbacv1.PolicyRule{
 		{
 			APIGroups:     []string{"security.openshift.io"},
-			ResourceNames: []string{"anyuid", "privileged"},
+			ResourceNames: []string{"anyuid", "hostmount-anyuid"},
 			Resources:     []string{"securitycontextconstraints"},
 			Verbs:         []string{"use"},
 		},

--- a/pkg/neutronapi/const.go
+++ b/pkg/neutronapi/const.go
@@ -12,6 +12,10 @@ const (
 	// Database -
 	Database = "neutron"
 
+	// neutron:neutron
+	NeutronUid int64 = 42435
+	NeutronGid int64 = 42435
+
 	// NeutronPublicPort -
 	NeutronPublicPort int32 = 9696
 	// NeutronInternalPort -

--- a/pkg/neutronapi/dbsync.go
+++ b/pkg/neutronapi/dbsync.go
@@ -14,8 +14,6 @@ func DbSyncJob(
 	annotations map[string]string,
 ) *batchv1.Job {
 	dbSyncExtraMounts := []neutronv1beta1.NeutronExtraVolMounts{}
-	runAsUser := int64(0)
-
 	volumeMounts := GetVolumeMounts("db-sync", dbSyncExtraMounts, DbsyncPropagation)
 	volumes := GetVolumes(cr.Name, dbSyncExtraMounts, DbsyncPropagation)
 
@@ -33,14 +31,12 @@ func DbSyncJob(
 					ServiceAccountName: cr.RbacResourceName(),
 					Containers: []corev1.Container{
 						{
-							Command: []string{"neutron-db-manage"},
-							Args:    []string{"upgrade", "heads"},
-							Name:    cr.Name + "-db-sync",
-							Image:   cr.Spec.ContainerImage,
-							SecurityContext: &corev1.SecurityContext{
-								RunAsUser: &runAsUser,
-							},
-							VolumeMounts: volumeMounts,
+							Command:         []string{"neutron-db-manage"},
+							Args:            []string{"upgrade", "heads"},
+							Name:            cr.Name + "-db-sync",
+							Image:           cr.Spec.ContainerImage,
+							SecurityContext: getNeutronSecurityContext(),
+							VolumeMounts:    volumeMounts,
 						},
 					},
 					Volumes: volumes,

--- a/pkg/neutronapi/deployment.go
+++ b/pkg/neutronapi/deployment.go
@@ -35,8 +35,6 @@ func Deployment(
 	labels map[string]string,
 	annotations map[string]string,
 ) *appsv1.Deployment {
-	runAsUser := int64(0)
-
 	livenessProbe := &corev1.Probe{
 		// TODO might need tuning
 		TimeoutSeconds:      5,
@@ -102,13 +100,11 @@ func Deployment(
 					ServiceAccountName: instance.RbacResourceName(),
 					Containers: []corev1.Container{
 						{
-							Name:    ServiceName + "-api",
-							Command: []string{cmd},
-							Args:    args,
-							Image:   instance.Spec.ContainerImage,
-							SecurityContext: &corev1.SecurityContext{
-								RunAsUser: &runAsUser,
-							},
+							Name:                     ServiceName + "-api",
+							Command:                  []string{cmd},
+							Args:                     args,
+							Image:                    instance.Spec.ContainerImage,
+							SecurityContext:          getNeutronSecurityContext(),
 							Env:                      env.MergeEnvs([]corev1.EnvVar{}, envVars),
 							VolumeMounts:             GetVolumeMounts("neutron-api", instance.Spec.ExtraMounts, NeutronAPIPropagation),
 							Resources:                instance.Spec.Resources,

--- a/pkg/neutronapi/scc.go
+++ b/pkg/neutronapi/scc.go
@@ -1,0 +1,22 @@
+package neutronapi
+
+import corev1 "k8s.io/api/core/v1"
+
+func getNeutronSecurityContext() *corev1.SecurityContext {
+	falseVal := false
+	trueVal := true
+	runAsUser := int64(NeutronUid)
+	runAsGroup := int64(NeutronGid)
+
+	return &corev1.SecurityContext{
+		RunAsUser:                &runAsUser,
+		RunAsGroup:               &runAsGroup,
+		RunAsNonRoot:             &trueVal,
+		AllowPrivilegeEscalation: &falseVal,
+		Capabilities: &corev1.Capabilities{
+			Drop: []corev1.Capability{
+				"ALL",
+			},
+		},
+	}
+}

--- a/pkg/neutronapi/volumes.go
+++ b/pkg/neutronapi/volumes.go
@@ -11,15 +11,12 @@ import (
 //
 //	mechanism.
 func GetVolumes(name string, extraVol []neutronv1beta1.NeutronExtraVolMounts, svc []storage.PropagationType) []corev1.Volume {
-	var config0640AccessMode int32 = 0640
-
 	res := []corev1.Volume{
 		{
 			Name: "config",
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					DefaultMode: &config0640AccessMode,
-					SecretName:  name + "-config",
+					SecretName: name + "-config",
 				},
 			},
 		},

--- a/test/kuttl/common/assert_sample_deployment.yaml
+++ b/test/kuttl/common/assert_sample_deployment.yaml
@@ -95,7 +95,7 @@ spec:
           timeoutSeconds: 5
         resources: {}
         securityContext:
-          runAsUser: 0
+          runAsUser: 42435
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: FallbackToLogsOnError
       schedulerName: default-scheduler


### PR DESCRIPTION
Now that we removed kolla bits from the startup path, we can unprivilege the containers.

Note: since we still may mount HostPaths, we have to stick to hostmount-anyuid for now. If this interface is revisited and e.g. switched to PVCs, then we should be able to tighten SCC a bit more.