### PR TITLE
Wait for db-sync completion before creating neutronapi Deployment

### DIFF
--- a/controllers/neutronapi_controller.go
+++ b/controllers/neutronapi_controller.go
@@ -366,7 +366,7 @@ func (r *NeutronAPIReconciler) reconcileInit(
 	} else if hashChanged {
 		// Hash changed and instance status should be updated (which will be done by main defer func),
 		// so we need to return and reconcile again
-		return ctrl.Result{}, nil
+		return ctrl.Result{Requeue: true}, nil
 	}
 	// Create Secrets - end
 


### PR DESCRIPTION
After recent changes that removed kolla from the startup path, the code that calculated new hash values was moved from the main reconcileNormal into reconcileInit subroutine. This made immediate return on input hash change from reconcileInit not to circumvert further loop execution, as was before the patch, but instead to proceed with the execution of the "main" procedure, incl. creating the neutronapi Deployment.

This behavior resulted in neutronapi startup before the db was initialized, which could be observed as failure of the API container with error messages about missing tables in neutron database.

This patch explicitly requests a Requeue on input hash change, which stops the current loop execution before the Deployment is created.

Note: it is unclear how to validate the fix in test environment because what we'd have to validate is whether the reconcile loop did NOT create a Deployment, and it's not clear how to be sure that the code had a chance to do it but decided not to, comparing to a case where the reconcile was slower than the test scenario. Hence, leaving the patch without new test coverage.

Resolves: https://issues.redhat.com/browse/OSP-29534

Fixes: 7a750f104a ("Remove kolla bits from service configuration path")