### PR TITLE
Update tenant_network_types to allow other types to be created

### DIFF
--- a/templates/neutronapi/config/01-neutron.conf
+++ b/templates/neutronapi/config/01-neutron.conf
@@ -16,13 +16,19 @@ connection=mysql+pymysql://{{ .DbUser }}:{{ .DbPassword }}@{{ .DbHost }}/{{ .Db 
 [ml2]
 mechanism_drivers = ovn
 type_drivers = local,flat,vlan,geneve,vxlan
-tenant_network_types = geneve
+tenant_network_types = geneve,vxlan,vlan,flat
 extension_drivers = qos,port_security,dns_domain_ports
 overlay_ip_version = 4
 
 [ml2_type_geneve]
 vni_ranges = 1:65536
 max_header_size = 38
+
+[ml2_type_vlan]
+network_vlan_ranges = datacentre
+
+[ml2_type_vxlan]
+vni_ranges = 1:65536
 
 [securitygroup]
 enable_security_group = true


### PR DESCRIPTION
Currently only geneve tenant networks are allowed, open up it to allow other network types to be created by default.