### PR TITLE
Create EDP Secret for Neutron OVN Agent

### DIFF
--- a/pkg/neutronapi/const.go
+++ b/pkg/neutronapi/const.go
@@ -33,6 +33,9 @@ const (
 	// Key in external Secret for Neutron OVN Metadata Agent with agent config
 	NeutronOVNMetadataAgentSecretKey = "10-neutron-metadata.conf"
 
+	// Key in external Secret for Neutron OVN Agent with agent config
+	NeutronOVNAgentSecretKey = "10-neutron-ovn.conf"
+
 	// Key in external Secret for Neutron SR-IOV Agent with agent config
 	NeutronSriovAgentSecretKey = "10-neutron-sriov.conf"
 

--- a/templates/ovn-agent.conf
+++ b/templates/ovn-agent.conf
@@ -1,0 +1,3 @@
+[ovn]
+ovn_nb_connection = {{ .NBConnection }}
+ovn_sb_connection = {{ .SBConnection }}

--- a/test/functional/base_test.go
+++ b/test/functional/base_test.go
@@ -37,7 +37,7 @@ const (
 	interval = timeout / 100
 )
 
-func SetExternalSBEndpoint(name types.NamespacedName, endpoint string) {
+func SetExternalDBEndpoint(name types.NamespacedName, endpoint string) {
 	Eventually(func(g Gomega) {
 		cluster := GetOVNDBCluster(name)
 		cluster.Status.DBAddress = endpoint

--- a/test/functional/neutronapi_controller_test.go
+++ b/test/functional/neutronapi_controller_test.go
@@ -461,7 +461,7 @@ var _ = Describe("NeutronAPI controller", func() {
 			DeferCleanup(DeleteOVNDBClusters, dbs)
 
 			externalSBEndpoint := "10.0.0.254"
-			SetExternalSBEndpoint(dbs[1], externalSBEndpoint)
+			SetExternalDBEndpoint(dbs[1], externalSBEndpoint)
 
 			externalMetadataAgentSecret := types.NamespacedName{
 				Namespace: neutronAPIName.Namespace,
@@ -486,7 +486,7 @@ var _ = Describe("NeutronAPI controller", func() {
 			DeferCleanup(DeleteOVNDBClusters, dbs)
 
 			externalSBEndpoint := "10.0.0.254"
-			SetExternalSBEndpoint(dbs[1], externalSBEndpoint)
+			SetExternalDBEndpoint(dbs[1], externalSBEndpoint)
 
 			externalMetadataAgentSecret := types.NamespacedName{
 				Namespace: neutronAPIName.Namespace,
@@ -520,7 +520,7 @@ var _ = Describe("NeutronAPI controller", func() {
 			DeferCleanup(DeleteOVNDBClusters, dbs)
 
 			externalSBEndpoint := "10.0.0.254"
-			SetExternalSBEndpoint(dbs[1], externalSBEndpoint)
+			SetExternalDBEndpoint(dbs[1], externalSBEndpoint)
 
 			externalMetadataAgentSecret := types.NamespacedName{
 				Namespace: neutronAPIName.Namespace,
@@ -543,7 +543,7 @@ var _ = Describe("NeutronAPI controller", func() {
 			initialHash := NeutronAPI.Status.Hash[externalMetadataAgentSecret.Name]
 
 			newExternalSBEndpoint := "10.0.0.250"
-			SetExternalSBEndpoint(dbs[1], newExternalSBEndpoint)
+			SetExternalDBEndpoint(dbs[1], newExternalSBEndpoint)
 
 			Eventually(func(g Gomega) {
 				g.Expect(th.GetSecret(externalMetadataAgentSecret).Data[neutronapi.NeutronOVNMetadataAgentSecretKey]).Should(
@@ -574,6 +574,121 @@ var _ = Describe("NeutronAPI controller", func() {
 			Expect(th.GetSecret(secret).Data["01-neutron.conf"]).Should(
 				ContainSubstring("memcached_servers=inet:[memcached-0.memcached]:11211,inet:[memcached-1.memcached]:11211,inet:[memcached-2.memcached]:11211"))
 
+		})
+
+		It("should create an external Ovn Agent Secret with expected ovn nb and sb connection set", func() {
+			dbs := CreateOVNDBClusters(namespace)
+			DeferCleanup(DeleteOVNDBClusters, dbs)
+
+			externalNBEndpoint := "10.0.0.253"
+			SetExternalDBEndpoint(dbs[0], externalNBEndpoint)
+			externalSBEndpoint := "10.0.0.254"
+			SetExternalDBEndpoint(dbs[1], externalSBEndpoint)
+
+			externalOvnAgentSecret := types.NamespacedName{
+				Namespace: neutronAPIName.Namespace,
+				Name:      fmt.Sprintf("%s-ovn-agent-neutron-config", neutronAPIName.Name),
+			}
+
+			Eventually(func() corev1.Secret {
+				return th.GetSecret(externalOvnAgentSecret)
+			}, timeout, interval).ShouldNot(BeNil())
+
+			Expect(th.GetSecret(externalOvnAgentSecret).Data[neutronapi.NeutronOVNAgentSecretKey]).Should(
+				ContainSubstring("ovn_nb_connection = %s", externalNBEndpoint))
+			Expect(th.GetSecret(externalOvnAgentSecret).Data[neutronapi.NeutronOVNAgentSecretKey]).Should(
+				ContainSubstring("ovn_sb_connection = %s", externalSBEndpoint))
+
+			Eventually(func(g Gomega) {
+				NeutronAPI := GetNeutronAPI(neutronAPIName)
+				g.Expect(NeutronAPI.Status.Hash[externalOvnAgentSecret.Name]).NotTo(BeEmpty())
+			}, timeout, interval).Should(Succeed())
+		})
+
+		It("should delete Ovn Agent external Secret once NB or SB DBClusters are deleted", func() {
+			dbs := CreateOVNDBClusters(namespace)
+			DeferCleanup(DeleteOVNDBClusters, dbs)
+			externalNBEndpoint := "10.0.0.253"
+			SetExternalDBEndpoint(dbs[0], externalNBEndpoint)
+
+			externalSBEndpoint := "10.0.0.254"
+			SetExternalDBEndpoint(dbs[1], externalSBEndpoint)
+
+			externalOvnAgentSecret := types.NamespacedName{
+				Namespace: neutronAPIName.Namespace,
+				Name:      fmt.Sprintf("%s-ovn-agent-neutron-config", neutronAPIName.Name),
+			}
+
+			Eventually(func() corev1.Secret {
+				return th.GetSecret(externalOvnAgentSecret)
+			}, timeout, interval).ShouldNot(BeNil())
+
+			Eventually(func(g Gomega) {
+				NeutronAPI := GetNeutronAPI(neutronAPIName)
+				g.Expect(NeutronAPI.Status.Hash[externalOvnAgentSecret.Name]).NotTo(BeEmpty())
+			}, timeout, interval).Should(Succeed())
+
+			DeleteOVNDBClusters([]types.NamespacedName{dbs[1]})
+
+			Eventually(func(g Gomega) {
+				secret := &corev1.Secret{}
+				g.Expect(k8sClient.Get(ctx, externalOvnAgentSecret, secret)).Should(HaveOccurred())
+			}, timeout, interval).Should(Succeed())
+
+			Eventually(func(g Gomega) {
+				NeutronAPI := GetNeutronAPI(neutronAPIName)
+				g.Expect(NeutronAPI.Status.Hash[externalOvnAgentSecret.Name]).To(BeEmpty())
+			}, timeout, interval).Should(Succeed())
+		})
+
+		It("should update Neutron Ovn Agent Secret once NB or SB DBCluster is updated", func() {
+			dbs := CreateOVNDBClusters(namespace)
+			DeferCleanup(DeleteOVNDBClusters, dbs)
+			externalNBEndpoint := "10.0.0.253"
+			SetExternalDBEndpoint(dbs[0], externalNBEndpoint)
+
+			externalSBEndpoint := "10.0.0.254"
+			SetExternalDBEndpoint(dbs[1], externalSBEndpoint)
+
+			externalOvnAgentSecret := types.NamespacedName{
+				Namespace: neutronAPIName.Namespace,
+				Name:      fmt.Sprintf("%s-ovn-agent-neutron-config", neutronAPIName.Name),
+			}
+
+			Eventually(func() corev1.Secret {
+				return th.GetSecret(externalOvnAgentSecret)
+			}, timeout, interval).ShouldNot(BeNil())
+			Expect(th.GetSecret(externalOvnAgentSecret).Data[neutronapi.NeutronOVNAgentSecretKey]).Should(
+				ContainSubstring("ovn_sb_connection = %s", externalSBEndpoint))
+
+			Eventually(func(g Gomega) {
+				NeutronAPI := GetNeutronAPI(neutronAPIName)
+				initialHash := NeutronAPI.Status.Hash[externalOvnAgentSecret.Name]
+				g.Expect(initialHash).NotTo(BeEmpty())
+			}, timeout, interval).Should(Succeed())
+
+			NeutronAPI := GetNeutronAPI(neutronAPIName)
+			initialHash := NeutronAPI.Status.Hash[externalOvnAgentSecret.Name]
+
+			newExternalNBEndpoint := "10.0.0.249"
+			SetExternalDBEndpoint(dbs[0], newExternalNBEndpoint)
+			newExternalSBEndpoint := "10.0.0.250"
+			SetExternalDBEndpoint(dbs[1], newExternalSBEndpoint)
+
+			Eventually(func(g Gomega) {
+				g.Expect(th.GetSecret(externalOvnAgentSecret).Data[neutronapi.NeutronOVNAgentSecretKey]).Should(
+					ContainSubstring("ovn_nb_connection = %s", newExternalNBEndpoint))
+			}, timeout, interval).Should(Succeed())
+			Eventually(func(g Gomega) {
+				g.Expect(th.GetSecret(externalOvnAgentSecret).Data[neutronapi.NeutronOVNAgentSecretKey]).Should(
+					ContainSubstring("ovn_sb_connection = %s", newExternalSBEndpoint))
+			}, timeout, interval).Should(Succeed())
+
+			Eventually(func(g Gomega) {
+				NeutronAPI := GetNeutronAPI(neutronAPIName)
+				newHash := NeutronAPI.Status.Hash[externalOvnAgentSecret.Name]
+				g.Expect(newHash).NotTo(Equal(initialHash))
+			}, timeout, interval).Should(Succeed())
 		})
 	})
 


### PR DESCRIPTION
OVN NB and SB DB connection strings are exported with this secret as these are required by neutron-ovn-agent[1].

[1] https://github.com/openstack-k8s-operators/edpm-ansible/pull/463
Related-Issue: [OSP-26191](https://issues.redhat.com//browse/OSP-26191)