### PR TITLE
Enable mysql_wsrep_sync_wait galera db option

### DIFF
--- a/templates/neutronapi/config/01-neutron.conf
+++ b/templates/neutronapi/config/01-neutron.conf
@@ -12,6 +12,9 @@ rpc_workers = 1
 
 [database]
 connection=mysql+pymysql://{{ .DbUser }}:{{ .DbPassword }}@{{ .DbHost }}/{{ .Db }}
+# NOTE(ykarel): It is required to be set for multi master galera, without it set
+# there can be reads from not up to date db instance and that leads to various issues.
+mysql_wsrep_sync_wait = 1
 
 [ml2]
 mechanism_drivers = ovn

--- a/test/functional/neutronapi_controller_test.go
+++ b/test/functional/neutronapi_controller_test.go
@@ -404,6 +404,8 @@ var _ = Describe("NeutronAPI controller", func() {
 				ContainSubstring("api_workers = 2"))
 			Expect(th.GetSecret(secret).Data["01-neutron.conf"]).Should(
 				ContainSubstring("rpc_workers = 1"))
+			Expect(th.GetSecret(secret).Data["01-neutron.conf"]).Should(
+				ContainSubstring("mysql_wsrep_sync_wait = 1"))
 
 		})
 


### PR DESCRIPTION
It is required to be set for multi master galera, without it set there can be reads from not up to date db instance and that leads to various issues.