### PR TITLE
Configure placement client

### DIFF
--- a/controllers/neutronapi_controller.go
+++ b/controllers/neutronapi_controller.go
@@ -1228,7 +1228,6 @@ func (r *NeutronAPIReconciler) generateServiceSecrets(
 	// Other OpenStack services
 	servicePassword := string(ospSecret.Data[instance.Spec.PasswordSelectors.Service])
 	databasePassword := string(ospSecret.Data[instance.Spec.PasswordSelectors.Database])
-	templateParameters["NovaPassword"] = servicePassword
 	templateParameters["ServicePassword"] = servicePassword
 
 	// Database

--- a/templates/neutronapi/config/01-neutron.conf
+++ b/templates/neutronapi/config/01-neutron.conf
@@ -52,7 +52,7 @@ project_domain_name = Default
 user_domain_name = Default
 project_name = service
 username = {{ .ServiceUser }}
-password={{ .ServicePassword }}
+password = {{ .ServicePassword }}
 interface = internal
 
 [nova]
@@ -63,7 +63,17 @@ user_domain_name = Default
 region_name = regionOne
 username = {{ .ServiceUser }}
 endpoint_type = internal
-password={{ .NovaPassword }}
+password = {{ .ServicePassword }}
+
+[placement]
+auth_url = {{ .KeystoneInternalURL }}
+auth_type = password
+project_domain_name = Default
+user_domain_name = Default
+region_name = regionOne
+username = {{ .ServiceUser }}
+endpoint_type = internal
+password = {{ .ServicePassword }}
 
 [oslo_concurrency]
 lock_path = /var/lib/neutron/tmp


### PR DESCRIPTION
Segment plugin reports MissingAuthPlugin Exception when placement section is not configured, let's configure it.

Also Use ServicePassword consistantly as we use generic service user/password to talk to other services.

Related-Issue: [OSP-29953](https://issues.redhat.com//browse/OSP-29953)