### PR TITLE
required infra annotations for OCP 4.14+

### DIFF
--- a/config/manifests/bases/neutron-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/neutron-operator.clusterserviceversion.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
+    features.operators.openshift.io/disconnected: "true"
     operatorframework.io/suggested-namespace: openstack
     operators.openshift.io/infrastructure-features: '["disconnected"]'
     operators.operatorframework.io/operator-type: non-standalone


### PR DESCRIPTION
Update to use new 'features.operators.openshift.io' annotations format for disconnected support

Jira: [OSP-30201](https://issues.redhat.com//browse/OSP-30201)