### PR TITLE
Add httpd sidecontainer for the Neutron API

### DIFF
--- a/controllers/neutronapi_controller.go
+++ b/controllers/neutronapi_controller.go
@@ -1337,6 +1337,17 @@ func (r *NeutronAPIReconciler) generateServiceSecrets(
 			Labels:        cmLabels,
 			ConfigOptions: templateParameters,
 		},
+		{
+			Name:         fmt.Sprintf("%s-httpd-config", instance.Name),
+			Namespace:    instance.Namespace,
+			Type:         util.TemplateTypeNone,
+			InstanceType: instance.Kind,
+			Labels:       cmLabels,
+			AdditionalTemplate: map[string]string{
+				"httpd.conf":            "/neutronapi/httpd/httpd.conf",
+				"10-neutron-httpd.conf": "/neutronapi/httpd/10-neutron-httpd.conf",
+			},
+		},
 	}
 	return secret.EnsureSecrets(ctx, h, instance, secrets, envVars)
 }

--- a/pkg/neutronapi/scc.go
+++ b/pkg/neutronapi/scc.go
@@ -20,3 +20,11 @@ func getNeutronSecurityContext() *corev1.SecurityContext {
 		},
 	}
 }
+
+func getNeutronHttpdSecurityContext() *corev1.SecurityContext {
+	runAsUser := int64(0)
+
+	return &corev1.SecurityContext{
+		RunAsUser: &runAsUser,
+	}
+}

--- a/pkg/neutronapi/volumes.go
+++ b/pkg/neutronapi/volumes.go
@@ -20,6 +20,14 @@ func GetVolumes(name string, extraVol []neutronv1beta1.NeutronExtraVolMounts, sv
 				},
 			},
 		},
+		{
+			Name: "httpd-config",
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: name + "-httpd-config",
+				},
+			},
+		},
 	}
 	for _, exv := range extraVol {
 		for _, vol := range exv.Propagate(svc) {
@@ -46,4 +54,20 @@ func GetVolumeMounts(serviceName string, extraVol []neutronv1beta1.NeutronExtraV
 	}
 	return res
 
+} // GetHttpdVolumeMount - Returns the VolumeMounts used by the httpd sidecar
+func GetHttpdVolumeMount() []corev1.VolumeMount {
+	return []corev1.VolumeMount{
+		{
+			Name:      "httpd-config",
+			MountPath: "/etc/httpd/conf/httpd.conf",
+			SubPath:   "httpd.conf",
+			ReadOnly:  true,
+		},
+		{
+			Name:      "httpd-config",
+			MountPath: "/etc/httpd/conf.d/10-neutron.conf",
+			SubPath:   "10-neutron-httpd.conf",
+			ReadOnly:  true,
+		},
+	}
 }

--- a/templates/neutronapi/config/01-neutron.conf
+++ b/templates/neutronapi/config/01-neutron.conf
@@ -1,4 +1,6 @@
 [DEFAULT]
+bind_host = 127.0.0.1
+bind_port = 9697
 transport_url={{ .TransportURL }}
 auth_strategy = keystone
 core_plugin = neutron.plugins.ml2.plugin.Ml2Plugin

--- a/templates/neutronapi/httpd/10-neutron-httpd.conf
+++ b/templates/neutronapi/httpd/10-neutron-httpd.conf
@@ -1,0 +1,21 @@
+<VirtualHost *:9696>
+  ## Logging
+  ErrorLog /dev/stdout
+  ServerSignature Off
+  CustomLog /dev/stdout combined
+
+  ## Request header rules
+  ## as per http://httpd.apache.org/docs/2.2/mod/mod_headers.html#requestheader
+  RequestHeader set X-Forwarded-Proto "https"
+
+  ## Proxy rules
+  ProxyRequests Off
+  ProxyPreserveHost Off
+  ProxyPass / http://localhost:9697/ retry=10
+  ProxyPassReverse / http://localhost:9697/
+
+  ## SSL directives
+  #SSLEngine on
+  #SSLCertificateFile      "/etc/pki/tls/certs/httpd/httpd-internal_api.crt"
+  #SSLCertificateKeyFile   "/etc/pki/tls/private/httpd/httpd-internal_api.key"
+</VirtualHost>

--- a/templates/neutronapi/httpd/httpd.conf
+++ b/templates/neutronapi/httpd/httpd.conf
@@ -1,0 +1,23 @@
+ServerTokens Prod
+ServerSignature Off
+TraceEnable Off
+ServerRoot "/etc/httpd"
+ServerName "neutron.openstack.svc"
+
+User apache
+Group apache
+
+Listen 9696
+
+TypesConfig /etc/mime.types
+
+Include conf.modules.d/*.conf
+
+LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
+LogFormat "%{X-Forwarded-For}i %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" proxy
+
+SetEnvIf X-Forwarded-For "^.*\..*\..*\..*" forwarded
+CustomLog /dev/stdout combined env=!forwarded
+CustomLog /dev/stdout proxy env=forwarded
+
+Include conf.d/10-neutron.conf

--- a/test/functional/neutronapi_controller_test.go
+++ b/test/functional/neutronapi_controller_test.go
@@ -816,17 +816,20 @@ var _ = Describe("NeutronAPI controller", func() {
 				},
 			)
 			Expect(int(*deployment.Spec.Replicas)).To(Equal(1))
-			Expect(deployment.Spec.Template.Spec.Volumes).To(HaveLen(1))
-			Expect(deployment.Spec.Template.Spec.Containers).To(HaveLen(1))
+			Expect(deployment.Spec.Template.Spec.Volumes).To(HaveLen(2))
+			Expect(deployment.Spec.Template.Spec.Containers).To(HaveLen(2))
 
-			container := deployment.Spec.Template.Spec.Containers[0]
-			Expect(container.LivenessProbe.HTTPGet.Port.IntVal).To(Equal(int32(9696)))
-			Expect(container.ReadinessProbe.HTTPGet.Port.IntVal).To(Equal(int32(9696)))
-			Expect(container.VolumeMounts).To(HaveLen(1))
-			Expect(container.Image).To(Equal("test-neutron-container-image"))
+			nSvcContainer := deployment.Spec.Template.Spec.Containers[0]
+			Expect(nSvcContainer.LivenessProbe.HTTPGet.Port.IntVal).To(Equal(int32(9696)))
+			Expect(nSvcContainer.ReadinessProbe.HTTPGet.Port.IntVal).To(Equal(int32(9696)))
+			Expect(nSvcContainer.VolumeMounts).To(HaveLen(1))
+			Expect(nSvcContainer.Image).To(Equal("test-neutron-container-image"))
 
-			Expect(container.LivenessProbe.HTTPGet.Port.IntVal).To(Equal(int32(9696)))
-			Expect(container.ReadinessProbe.HTTPGet.Port.IntVal).To(Equal(int32(9696)))
+			nHttpdProxyContainer := deployment.Spec.Template.Spec.Containers[1]
+			Expect(nHttpdProxyContainer.LivenessProbe.HTTPGet.Port.IntVal).To(Equal(int32(9696)))
+			Expect(nHttpdProxyContainer.ReadinessProbe.HTTPGet.Port.IntVal).To(Equal(int32(9696)))
+			Expect(nHttpdProxyContainer.VolumeMounts).To(HaveLen(2))
+			Expect(nHttpdProxyContainer.Image).To(Equal("test-neutron-container-image"))
 		})
 	})
 

--- a/test/kuttl/common/assert_sample_deployment.yaml
+++ b/test/kuttl/common/assert_sample_deployment.yaml
@@ -98,6 +98,35 @@ spec:
           runAsUser: 42435
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: FallbackToLogsOnError
+      - command:
+        - /usr/sbin/httpd
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /
+            port: 9696
+            scheme: HTTP
+          initialDelaySeconds: 20
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 5
+        name: neutron-httpd
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /
+            port: 9696
+            scheme: HTTP
+          initialDelaySeconds: 20
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 5
+        resources: {}
+        securityContext:
+          runAsUser: 0
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: FallbackToLogsOnError
       schedulerName: default-scheduler
       securityContext: {}
       serviceAccount: neutron-neutron


### PR DESCRIPTION
This patch introduces an additional sidecontainer for the NeutronAPI that is
supposed to ProxyPass requests to the neutron-api process behind. This will also solve the problem of tls-everywhere for Neutron, where the second segment is re-encrypted from the Route (created by the openstack operator) to the deployment.

* The httpd will serve requests on 9696, while the neutron-api service will be run locally on 9697
* httpd instance will be customized in a follow up patch to mount certificates and add the related ssl directives

Jira: [OSP-29184](https://issues.redhat.com//browse/OSP-29184)