### PR TITLE
Include status.networkAttachments in PrinterColumns

### DIFF
--- a/api/bases/neutron.openstack.org_neutronapis.yaml
+++ b/api/bases/neutron.openstack.org_neutronapis.yaml
@@ -17,7 +17,7 @@ spec:
   versions:
   - additionalPrinterColumns:
     - description: NetworkAttachments
-      jsonPath: .spec.networkAttachments
+      jsonPath: .status.networkAttachments
       name: NetworkAttachments
       type: string
     - description: Status

--- a/api/v1beta1/neutronapi_types.go
+++ b/api/v1beta1/neutronapi_types.go
@@ -193,7 +193,7 @@ type NeutronAPIStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:printcolumn:name="NetworkAttachments",type="string",JSONPath=".spec.networkAttachments",description="NetworkAttachments"
+// +kubebuilder:printcolumn:name="NetworkAttachments",type="string",JSONPath=".status.networkAttachments",description="NetworkAttachments"
 // +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.conditions[0].status",description="Status"
 // +kubebuilder:printcolumn:name="Message",type="string",JSONPath=".status.conditions[0].message",description="Message"
 

--- a/config/crd/bases/neutron.openstack.org_neutronapis.yaml
+++ b/config/crd/bases/neutron.openstack.org_neutronapis.yaml
@@ -17,7 +17,7 @@ spec:
   versions:
   - additionalPrinterColumns:
     - description: NetworkAttachments
-      jsonPath: .spec.networkAttachments
+      jsonPath: .status.networkAttachments
       name: NetworkAttachments
       type: string
     - description: Status


### PR DESCRIPTION
Printing the status.networkAttachments instead of the spec part is more useful as it dumps pod IPs.