### PR TITLE
    Reintroduce kolla into startup path for neutron-api

### DIFF
--- a/pkg/neutronapi/scc.go
+++ b/pkg/neutronapi/scc.go
@@ -3,19 +3,17 @@ package neutronapi
 import corev1 "k8s.io/api/core/v1"
 
 func getNeutronSecurityContext() *corev1.SecurityContext {
-	falseVal := false
 	trueVal := true
 	runAsUser := int64(NeutronUid)
 	runAsGroup := int64(NeutronGid)
 
 	return &corev1.SecurityContext{
-		RunAsUser:                &runAsUser,
-		RunAsGroup:               &runAsGroup,
-		RunAsNonRoot:             &trueVal,
-		AllowPrivilegeEscalation: &falseVal,
+		RunAsUser:    &runAsUser,
+		RunAsGroup:   &runAsGroup,
+		RunAsNonRoot: &trueVal,
 		Capabilities: &corev1.Capabilities{
 			Drop: []corev1.Capability{
-				"ALL",
+				"MKNOD",
 			},
 		},
 	}

--- a/pkg/neutronapi/volumes.go
+++ b/pkg/neutronapi/volumes.go
@@ -43,7 +43,13 @@ func GetVolumeMounts(serviceName string, extraVol []neutronv1beta1.NeutronExtraV
 	res := []corev1.VolumeMount{
 		{
 			Name:      "config",
-			MountPath: "/etc/neutron.conf.d",
+			MountPath: "/var/lib/config-data",
+			ReadOnly:  true,
+		},
+		{
+			Name:      "config",
+			MountPath: "/var/lib/kolla/config_files/config.json",
+			SubPath:   serviceName + "-config.json",
 			ReadOnly:  true,
 		},
 	}

--- a/templates/neutronapi/config/db-sync-config.json
+++ b/templates/neutronapi/config/db-sync-config.json
@@ -1,0 +1,17 @@
+{
+  "command": "neutron-db-manage --config-file /usr/share/neutron/neutron-dist.conf --config-file /etc/neutron/neutron.conf --config-dir /etc/neutron/neutron.conf.d upgrade heads",
+  "config_files": [
+    {
+      "source": "/var/lib/config-data/01-neutron.conf",
+      "dest": "/etc/neutron/neutron.conf.d/01-neutron.conf",
+      "owner": "root:neutron",
+      "perm": "0640"
+    },
+    {
+      "source": "/var/lib/config-data/02-neutron-custom.conf",
+      "dest": "/etc/neutron/neutron.conf.d/02-neutron-custom.conf",
+      "owner": "root:neutron",
+      "perm": "0640"
+    }
+  ]
+}

--- a/templates/neutronapi/config/neutron-api-config.json
+++ b/templates/neutronapi/config/neutron-api-config.json
@@ -1,0 +1,17 @@
+{
+  "command": "/usr/bin/neutron-server --config-file /usr/share/neutron/neutron-dist.conf --config-file /etc/neutron/neutron.conf --config-dir /etc/neutron/neutron.conf.d",
+  "config_files": [
+    {
+      "source": "/var/lib/config-data/01-neutron.conf",
+      "dest": "/etc/neutron/neutron.conf.d/01-neutron.conf",
+      "owner": "root:neutron",
+      "perm": "0640"
+    },
+    {
+      "source": "/var/lib/config-data/02-neutron-custom.conf",
+      "dest": "/etc/neutron/neutron.conf.d/02-neutron-custom.conf",
+      "owner": "root:neutron",
+      "perm": "0640"
+    }
+  ]
+}

--- a/test/functional/neutronapi_controller_test.go
+++ b/test/functional/neutronapi_controller_test.go
@@ -816,7 +816,7 @@ var _ = Describe("NeutronAPI controller", func() {
 			nSvcContainer := deployment.Spec.Template.Spec.Containers[0]
 			Expect(nSvcContainer.LivenessProbe.HTTPGet.Port.IntVal).To(Equal(int32(9696)))
 			Expect(nSvcContainer.ReadinessProbe.HTTPGet.Port.IntVal).To(Equal(int32(9696)))
-			Expect(nSvcContainer.VolumeMounts).To(HaveLen(1))
+			Expect(nSvcContainer.VolumeMounts).To(HaveLen(2))
 			Expect(nSvcContainer.Image).To(Equal("test-neutron-container-image"))
 
 			nHttpdProxyContainer := deployment.Spec.Template.Spec.Containers[1]

--- a/test/kuttl/common/assert_sample_deployment.yaml
+++ b/test/kuttl/common/assert_sample_deployment.yaml
@@ -70,7 +70,10 @@ spec:
             weight: 1
       containers:
       - command:
-        - /usr/bin/neutron-server
+        - /bin/bash
+        args:
+        - -c
+        - /usr/local/bin/kolla_start
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3


### PR DESCRIPTION
This is to keep neutron-api in line with [1] until we decide otherwise.

Keeping kolla has several drawbacks, specifically:

1. allowPrivilegeEscalation has to be true for sudo.
2. dropCapabilities cannot be ALL because kolla_set_configs failed to change to root gid.

This patch may be revisited later if we decide to tighten privileges further by patching our kolla fork, or removing kolla completely from the startup path. For now, we'll have to stick to common approach.

The discussion over kolla place can be continued in jira [2].

[1] https://github.com/openstack-k8s-operators/docs/blob/main/service_config.md
[2] https://issues.redhat.com/browse/OSPRH-2240