### PR TITLE
Skip tempest job run for api/go.mod/sum changes

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -16,7 +16,7 @@
       - ^OWNERS$
       - ^OWNERS_ALIASES$
       - ^PROJECT$
-      - go.(mod|sum|work).*
+      - .*go.(mod|sum|work).*
       - ^kuttl-test.yaml$
       - ^renovate.json$
       - ^config/samples/.*$


### PR DESCRIPTION
These job unnecessary runs on renovate prs, kuttl
jobs enough for those changes, this patch extends
the previous regex for these files.