### PR TITLE
Set ProxyPreserveHost directive to "on" in the httpd container

### DIFF
--- a/templates/neutronapi/httpd/10-neutron-httpd.conf
+++ b/templates/neutronapi/httpd/10-neutron-httpd.conf
@@ -14,7 +14,7 @@
 
   ## Proxy rules
   ProxyRequests Off
-  ProxyPreserveHost Off
+  ProxyPreserveHost On
   ProxyPass / http://localhost:9697/ retry=10
   ProxyPassReverse / http://localhost:9697/
 

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -42,9 +42,6 @@
         # To check metadata with and without config drive
         - tempest.scenario.test_server_basic_ops.TestServerBasicOps.test_server_basic_ops
       cifmw_tempest_tests_skipped:
-        # https://issues.redhat.com/browse/OSPRH-3099
-        - test_list_pagination_page_reverse_with_href_links
-        - test_list_pagination_with_href_links
         # https://review.opendev.org/892839
         - neutron_tempest_plugin.scenario.test_mtu.NetworkWritableMtuTest
         # missing https://review.opendev.org/882818 in antelope


### PR DESCRIPTION
We need to pass original host from the API requests incomining to the neutron api server e.g. in order to have proper pagination links returned.

Closes: [OSPRH-3099](https://issues.redhat.com//browse/OSPRH-3099)