### PR TITLE
[tlse] TLS database connection

### DIFF
--- a/templates/neutronapi/config/01-neutron.conf
+++ b/templates/neutronapi/config/01-neutron.conf
@@ -13,7 +13,7 @@ api_workers = 2
 rpc_workers = 1
 
 [database]
-connection=mysql+pymysql://{{ .DbUser }}:{{ .DbPassword }}@{{ .DbHost }}/{{ .Db }}
+connection=mysql+pymysql://{{ .DbUser }}:{{ .DbPassword }}@{{ .DbHost }}/{{ .Db }}?read_default_file=/etc/my.cnf
 # NOTE(ykarel): It is required to be set for multi master galera, without it set
 # there can be reads from not up to date db instance and that leads to various issues.
 mysql_wsrep_sync_wait = 1

--- a/templates/neutronapi/config/db-sync-config.json
+++ b/templates/neutronapi/config/db-sync-config.json
@@ -12,6 +12,12 @@
       "dest": "/etc/neutron/neutron.conf.d/02-neutron-custom.conf",
       "owner": "root:neutron",
       "perm": "0640"
+    },
+    {
+      "source": "/var/lib/config-data/my.cnf",
+      "dest": "/etc/my.cnf",
+      "owner": "neutron",
+      "perm": "0644"
     }
   ]
 }

--- a/templates/neutronapi/config/neutron-api-config.json
+++ b/templates/neutronapi/config/neutron-api-config.json
@@ -12,6 +12,12 @@
       "dest": "/etc/neutron/neutron.conf.d/02-neutron-custom.conf",
       "owner": "root:neutron",
       "perm": "0640"
+    },
+    {
+      "source": "/var/lib/config-data/my.cnf",
+      "dest": "/etc/my.cnf",
+      "owner": "neutron",
+      "perm": "0644"
     }
   ]
 }

--- a/test/functional/base_test.go
+++ b/test/functional/base_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/google/uuid"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -164,4 +165,15 @@ func GetOVNDBCluster(name types.NamespacedName) *ovnv1.OVNDBCluster {
 		g.Expect(k8sClient.Get(ctx, name, instance)).Should(Succeed())
 	}, timeout, interval).Should(Succeed())
 	return instance
+}
+
+func CreateNeutronAPISecret(namespace string, name string) *corev1.Secret {
+	return th.CreateSecret(
+		types.NamespacedName{Namespace: namespace, Name: name},
+		map[string][]byte{
+			"NeutronPassword":         []byte("12345678"),
+			"NeutronDatabasePassword": []byte("12345678"),
+			"transport_url":           []byte("rabbit://user@svc:1234"),
+		},
+	)
 }


### PR DESCRIPTION
The my.cnf file gets added to the secret holding the service configs. The content of my.cnf is centrally managed in the mariadb-operator and retrieved calling db.GetDatabaseClientConfig(tlsCfg)

Depends-On: https://github.com/openstack-k8s-operators/mariadb-operator/pull/190
Depends-On: https://github.com/openstack-k8s-operators/mariadb-operator/pull/191

Jira: [OSPRH-4547](https://issues.redhat.com//browse/OSPRH-4547)