### PR TITLE
Add kuttl test for neutron operator: change neutron debug config

### DIFF
--- a/test/kuttl/common/scripts/check_debug_in_neutron_pod_logs.sh
+++ b/test/kuttl/common/scripts/check_debug_in_neutron_pod_logs.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+pod=$(oc get pods -n $NAMESPACE -l service=neutron -o name)
+
+# Check if the neutron pod logs contain DEBUG messages
+oc logs -n $NAMESPACE "$pod" | grep -q "DEBUG"
+exit $?

--- a/test/kuttl/tests/change_neutron_config/01-assert.yaml
+++ b/test/kuttl/tests/change_neutron_config/01-assert.yaml
@@ -1,0 +1,1 @@
+../../common/assert_sample_deployment.yaml

--- a/test/kuttl/tests/change_neutron_config/01-deploy-neutron.yaml
+++ b/test/kuttl/tests/change_neutron_config/01-deploy-neutron.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: |
+      cp ../../../../config/samples/neutron_v1beta1_neutronapi.yaml deploy
+      oc kustomize deploy | oc apply -n $NAMESPACE -f -

--- a/test/kuttl/tests/change_neutron_config/02-assert.yaml
+++ b/test/kuttl/tests/change_neutron_config/02-assert.yaml
@@ -1,0 +1,6 @@
+# check that by default, debug is set in neutron config
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+  - script: |
+        $NEUTRON_KUTTL_DIR/../common/scripts/check_debug_in_neutron_pod_logs.sh

--- a/test/kuttl/tests/change_neutron_config/03-assert.yaml
+++ b/test/kuttl/tests/change_neutron_config/03-assert.yaml
@@ -1,0 +1,7 @@
+# check that now, debug is not set in neutron config
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+  - script: |
+      $NEUTRON_KUTTL_DIR/../common/scripts/check_debug_in_neutron_pod_logs.sh
+      test $? -ne 0

--- a/test/kuttl/tests/change_neutron_config/03-change_neutron_debug_config.yaml
+++ b/test/kuttl/tests/change_neutron_config/03-change_neutron_debug_config.yaml
@@ -1,0 +1,8 @@
+apiVersion: neutron.openstack.org/v1beta1
+kind: NeutronAPI
+metadata:
+  name: neutron
+spec:
+  customServiceConfig: |
+    [DEFAULT]
+    debug = false

--- a/test/kuttl/tests/change_neutron_config/04-cleanup-neutron.yaml
+++ b/test/kuttl/tests/change_neutron_config/04-cleanup-neutron.yaml
@@ -1,0 +1,1 @@
+../../common/cleanup-neutron.yaml

--- a/test/kuttl/tests/change_neutron_config/04-errors.yaml
+++ b/test/kuttl/tests/change_neutron_config/04-errors.yaml
@@ -1,0 +1,1 @@
+../../common/errors_cleanup_neutron.yaml

--- a/test/kuttl/tests/change_neutron_config/deploy/kustomization.yaml
+++ b/test/kuttl/tests/change_neutron_config/deploy/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ./neutron_v1beta1_neutronapi.yaml
+patches:
+- patch: |-
+    - op: replace
+      path: /spec/secret
+      value: osp-secret
+    - op: remove
+      path: /metadata/namespace
+  target:
+    kind: NeutronAPI


### PR DESCRIPTION
Implement a kuttl test to ensure that any modifications to the neutron service settings lead to the creation of a new pod with the updated settings. These tests should first confirm that the default logging setting excludes debug details. Then, after adjusting the neutron configuration to enable debug mode (debug = true), the tests should verify that the logs from the newly created pod now contain debug information.