### PR TITLE
Use bind_host=localhost

### DIFF
--- a/templates/neutronapi/config/01-neutron.conf
+++ b/templates/neutronapi/config/01-neutron.conf
@@ -1,5 +1,5 @@
 [DEFAULT]
-bind_host = 127.0.0.1
+bind_host = localhost
 bind_port = 9697
 transport_url={{ .TransportURL }}
 auth_strategy = keystone


### PR DESCRIPTION
Using localhost would allow bind_host to use the correct loopback address for ipv6.