### PR TITLE
Add default timeout for route annotations

### DIFF
--- a/api/v1beta1/neutronapi_types.go
+++ b/api/v1beta1/neutronapi_types.go
@@ -266,7 +266,8 @@ func (instance NeutronAPI) RbacResourceName() string {
 func SetupDefaults() {
 	// Acquire environmental defaults and initialize Neutron defaults with them
 	neutronDefaults := NeutronAPIDefaults{
-		ContainerImageURL: util.GetEnvVar("RELATED_IMAGE_NEUTRON_API_IMAGE_URL_DEFAULT", NeutronAPIContainerImage),
+		ContainerImageURL:      util.GetEnvVar("RELATED_IMAGE_NEUTRON_API_IMAGE_URL_DEFAULT", NeutronAPIContainerImage),
+		NeutronAPIRouteTimeout: "120s",
 	}
 
 	SetupNeutronAPIDefaults(neutronDefaults)

--- a/api/v1beta1/neutronapi_webhook.go
+++ b/api/v1beta1/neutronapi_webhook.go
@@ -32,7 +32,8 @@ import (
 
 // NeutronAPIDefaults -
 type NeutronAPIDefaults struct {
-	ContainerImageURL string
+	ContainerImageURL      string
+	NeutronAPIRouteTimeout string
 }
 
 var neutronAPIDefaults NeutronAPIDefaults
@@ -105,4 +106,11 @@ func (r *NeutronAPI) ValidateDelete() (admission.Warnings, error) {
 
 	// TODO(user): fill in your validation logic upon object deletion.
 	return nil, nil
+}
+
+func (spec *NeutronAPISpec) GetDefaultRouteAnnotations() (annotations map[string]string) {
+	annotations = map[string]string{
+		"haproxy.router.openshift.io/timeout": neutronAPIDefaults.NeutronAPIRouteTimeout,
+	}
+	return
 }


### PR DESCRIPTION
Add the timeout property as required annotation for the Neutron API Route. This needs to be followed by a commit in openstack-operator since the route is defined there. In that commit the GetDefaultRouteAnnotations method is used accordingly.

(Goes together with https://github.com/openstack-k8s-operators/openstack-operator/pull/722)