### PR TITLE
Add *core* validation for default route annotations

### DIFF
--- a/api/v1beta1/neutronapi_webhook.go
+++ b/api/v1beta1/neutronapi_webhook.go
@@ -109,6 +109,10 @@ func (r *NeutronAPI) ValidateDelete() (admission.Warnings, error) {
 }
 
 func (spec *NeutronAPISpec) GetDefaultRouteAnnotations() (annotations map[string]string) {
+	return spec.NeutronAPISpecCore.GetDefaultRouteAnnotations()
+}
+
+func (spec *NeutronAPISpecCore) GetDefaultRouteAnnotations() (annotations map[string]string) {
 	annotations = map[string]string{
 		"haproxy.router.openshift.io/timeout": neutronAPIDefaults.NeutronAPIRouteTimeout,
 	}


### PR DESCRIPTION
Add a *core* API spec version of the new
GetDefaultRouteAnnotations function. The new
OpenStackControlPlane PR will require use of this
version in order to leverage the same function.