### PR TITLE
DNM - Checking machineconfigpool degradation

### DIFF
--- a/controllers/neutronapi_controller.go
+++ b/controllers/neutronapi_controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 Red Hat
+Copyright 2022 Red Hat.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/playbooks/test.yaml
+++ b/playbooks/test.yaml
@@ -1,0 +1,8 @@
+---
+- name: Checking
+  hosts: all
+  tasks:
+    - name: List dirs
+      ansible.builtin.shell: |
+        ls
+        pwd

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -1,7 +1,136 @@
 ---
 - job:
+    name: cifmw-podified-multinode-edpm-base-crc-future
+    parent: base-future-extracted-crc
+    timeout: 10800
+    attempts: 1
+    nodeset: centos-9-medium-centos-9-crc-extracted-2.30-3xl
+    irrelevant-files: &ir_files
+      - .*/*.md
+      - ^.github/.*$
+      - ^LICENSE$
+      - ^OWNERS$
+      - ^OWNERS_ALIASES$
+      - ^PROJECT$
+      - ^README.md$
+      - ^renovate.json$
+      - ^kuttl-test.yaml$
+      - molecule/.*
+      - molecule-requirements.txt
+      - .github/workflows
+      - docs/.*
+      - contribute/.*
+      - roles/.*/molecule/.*
+      # ci-framework
+      - .readthedocs.yaml
+      - roles/dlrn_report
+      - roles/dlrn_promote
+      - roles/devscripts
+      # Other openstack operators
+      - containers/ci
+      - .ci-operator.yaml
+      - .dockerignore
+      - .gitignore
+      - .golangci.yaml
+      - .pre-commit-config.yaml
+      - tests?\/functional
+      # openstack-ansibleee-operator
+      - examples
+      - mkdocs.yml
+    required-projects: &multinode_edpm_rp
+      - openstack-k8s-operators/ci-framework
+      - openstack-k8s-operators/dataplane-operator
+      - openstack-k8s-operators/install_yamls
+      - openstack-k8s-operators/infra-operator
+      - openstack-k8s-operators/openstack-baremetal-operator
+      - openstack-k8s-operators/openstack-must-gather
+      - openstack-k8s-operators/openstack-operator
+      - openstack-k8s-operators/repo-setup
+      - openstack-k8s-operators/edpm-ansible
+    roles: &multinode_edpm_roles
+      - zuul: github.com/openstack-k8s-operators/ci-framework
+    pre-run:
+      - playbooks/test.yaml
+#    pre-run: &multinode_edpm_pre_run
+#      - ci/playbooks/multinode-customizations.yml
+#      - ci/playbooks/e2e-prepare.yml
+#      - ci/playbooks/dump_zuul_data.yml
+#    post-run: &multinode_edpm_post_run
+#      - ci/playbooks/e2e-collect-logs.yml
+#      - ci/playbooks/collect-logs.yml
+#      - ci/playbooks/multinode-autohold.yml
+    vars: &multinode_edpm_vars
+      zuul_log_collection: true
+      registry_login_enabled: true
+      push_registry: quay.rdoproject.org
+      quay_login_secret_name: quay_nextgen_zuulgithubci
+      cifmw_artifacts_crc_sshkey: "~/.ssh/id_cifw"
+      cifmw_openshift_user: kubeadmin
+      cifmw_openshift_password: "123456789"
+      cifmw_openshift_api: api.crc.testing:6443
+      cifmw_openshift_kubeconfig: "{{ ansible_user_dir }}/.crc/machines/crc/kubeconfig"
+      cifmw_openshift_skip_tls_verify: true
+      cifmw_use_libvirt: false
+      cifmw_zuul_target_host: controller
+      crc_ci_bootstrap_cloud_name: "{{ nodepool.cloud | replace('-nodepool-tripleo','') }}"
+      crc_ci_bootstrap_networking:
+        networks:
+          default:
+            mtu: "{{ ('ibm' in nodepool.cloud) | ternary('1440', '1500') }}"
+            router_net: "{{ ('ibm' in nodepool.cloud) | ternary('hostonly', 'public') }}"
+            range: 192.168.122.0/24
+          internal-api:
+            vlan: 20
+            range: 172.17.0.0/24
+          storage:
+            vlan: 21
+            range: 172.18.0.0/24
+          tenant:
+            vlan: 22
+            range: 172.19.0.0/24
+        instances:
+          controller:
+            networks:
+              default:
+                ip: 192.168.122.11
+          crc:
+            networks:
+              default:
+                ip: 192.168.122.10
+              internal-api:
+                ip: 172.17.0.5
+              storage:
+                ip: 172.18.0.5
+              tenant:
+                ip: 172.19.0.5
+          compute-0:
+            networks:
+              default:
+                ip: 192.168.122.100
+              internal-api:
+                ip: 172.17.0.100
+                config_nm: false
+              storage:
+                ip: 172.18.0.100
+                config_nm: false
+              tenant:
+                ip: 172.19.0.100
+                config_nm: false
+
+
+- job:
+    name: podified-multinode-edpm-deployment-crc-future
+    parent: cifmw-podified-multinode-edpm-base-crc-future
+#    vars:
+#      cifmw_extras:
+#        - '@scenarios/centos-9/multinode-ci.yml'
+    run:
+      - playbooks/test.yaml
+#      - ci/playbooks/edpm/run.yml
+
+- job:
     name: neutron-operator-tempest-multinode
-    parent: podified-multinode-edpm-deployment-crc
+    parent: podified-multinode-edpm-deployment-crc-future
     dependencies: ["openstack-k8s-operators-content-provider"]
     irrelevant-files:
       - .*/*.md
@@ -48,3 +177,4 @@
         - test_qos_dscp_create_and_update
         # Limit job runtime
         - NetworkSecGroupTest
+      change_machineconfigpool: true


### PR DESCRIPTION
Normally the machineconfigpool workaround would be used in all CI jobs base on the CRC extracted image.