### PR TITLE
Switch to tempest role for running tempest

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -27,6 +27,7 @@
       - ^zuul.d/(?!(project)).*\.yaml
     vars:
       cifmw_tempest_container: openstack-tempest-all
+      cifmw_run_test_role: tempest
       cifmw_tempest_tempestconf_profile:
           overrides:
             compute-feature-enabled.vnc_console: true


### PR DESCRIPTION
https://github.com/openstack-k8s-operators/ci-framework/pull/1391 moves to test_operator role for running tempest tests. It broke the existing vars based on tempest role.
It also needs to be migrated to test_operator.
Let use tempest role here to bring back running tempest tests.