### PR TITLE
Check Deployment ObservedGeneration to set ReadyCondition

### DIFF
--- a/test/functional/neutronapi_controller_test.go
+++ b/test/functional/neutronapi_controller_test.go
@@ -915,6 +915,7 @@ var _ = Describe("NeutronAPI controller", func() {
 				Name:      "neutron",
 			}
 			depl := th.GetDeployment(deplName)
+			th.SimulateDeploymentReadyWithPods(deplName, map[string][]string{})
 
 			expectedAnnotation, err := json.Marshal(
 				[]networkv1.NetworkSelectionElement{


### PR DESCRIPTION
`DeploymentReadyCondition` is something that depends on the number of ready `Replicas`, but it should also be influenced by the `ObservedGeneration`. We need to make sure that the readiness is set for the last `CR` version, and this patch adds the additional check that we're rolling out to the other operators as well.