### PR TITLE
Fix ObsGen condition check

### DIFF
--- a/controllers/neutronapi_controller.go
+++ b/controllers/neutronapi_controller.go
@@ -1009,7 +1009,7 @@ func (r *NeutronAPIReconciler) reconcileNormal(ctx context.Context, instance *ne
 		return ctrlResult, nil
 	}
 
-	if depl.GetDeployment().Generation <= depl.GetDeployment().Status.ObservedGeneration {
+	if depl.GetDeployment().Generation == depl.GetDeployment().Status.ObservedGeneration {
 		instance.Status.ReadyCount = depl.GetDeployment().Status.ReadyReplicas
 
 		// verify if network attachment matches expectations


### PR DESCRIPTION
As per the agreement in [1], the controller should evaluate the current CR readiness only when the Generation matches with the ObservedGeneration. Any other edge case can be handled by a separate check, but we do not want to risk to reach "ReadyCondition = True" when we see a Generation "<" of the ObservedGeneration.

[1] https://github.com/openstack-k8s-operators/dev-docs/pull/102