### PR TITLE
[tlse] Ensure input readiness reported after all certificates are ready

### DIFF
--- a/controllers/neutronapi_controller.go
+++ b/controllers/neutronapi_controller.go
@@ -495,6 +495,9 @@ func (r *NeutronAPIReconciler) reconcileInit(
 	}
 	secretVars[tls.TLSHashName] = env.SetValue(certsHash)
 
+	// all cert input checks out so report InputReady
+	instance.Status.Conditions.MarkTrue(condition.TLSInputReadyCondition, condition.InputReadyMessage)
+
 	//
 	// create hash over all the different input resources to identify if any those changed
 	// and a restart/recreate is required.

--- a/test/functional/neutronapi_controller_test.go
+++ b/test/functional/neutronapi_controller_test.go
@@ -1069,6 +1069,12 @@ var _ = Describe("NeutronAPI controller", func() {
 		})
 
 		It("it creates deployment with CA and service certs mounted", func() {
+			th.ExpectCondition(
+				neutronAPIName,
+				ConditionGetterFunc(NeutronAPIConditionGetter),
+				condition.TLSInputReadyCondition,
+				corev1.ConditionTrue,
+			)
 
 			deployment := th.GetDeployment(
 				types.NamespacedName{


### PR DESCRIPTION
Fixed a missing condition that prevented the deployment from being marked as ready, even though all certificates and attached secrets were properly prepared.