### PR TITLE
Ensure golangci-lint runs on all files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -69,5 +69,5 @@ repos:
 - repo: https://github.com/golangci/golangci-lint
   rev: v1.55.2
   hooks:
-    - id: golangci-lint
+    - id: golangci-lint-full
       args: ["-v"]

--- a/pkg/neutronapi/const.go
+++ b/pkg/neutronapi/const.go
@@ -20,8 +20,8 @@ const (
 	DatabaseUsernamePrefix = "neutron"
 
 	// neutron:neutron
-	NeutronUid int64 = 42435
-	NeutronGid int64 = 42435
+	NeutronUID int64 = 42435
+	NeutronGID int64 = 42435
 
 	// NeutronPublicPort -
 	NeutronPublicPort int32 = 9696

--- a/pkg/neutronapi/scc.go
+++ b/pkg/neutronapi/scc.go
@@ -4,8 +4,8 @@ import corev1 "k8s.io/api/core/v1"
 
 func getNeutronSecurityContext() *corev1.SecurityContext {
 	trueVal := true
-	runAsUser := int64(NeutronUid)
-	runAsGroup := int64(NeutronGid)
+	runAsUser := int64(NeutronUID)
+	runAsGroup := int64(NeutronGID)
 
 	return &corev1.SecurityContext{
 		RunAsUser:    &runAsUser,

--- a/test/functional/base_test.go
+++ b/test/functional/base_test.go
@@ -20,7 +20,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega" //revive:disable:dot-imports
 	corev1 "k8s.io/api/core/v1"
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -151,7 +151,7 @@ func DeleteOVNDBClusters(names []types.NamespacedName) {
 			if k8s_errors.IsNotFound(err) {
 				return
 			}
-			g.Expect(err).Should(BeNil())
+			g.Expect(err).ShouldNot(HaveOccurred())
 
 			g.Expect(k8sClient.Delete(ctx, ovndbcluster)).Should(Succeed())
 

--- a/test/functional/neutronapi_controller_test.go
+++ b/test/functional/neutronapi_controller_test.go
@@ -21,14 +21,16 @@ import (
 	"fmt"
 	"strings"
 
-	mariadbv1 "github.com/openstack-k8s-operators/mariadb-operator/api/v1beta1"
+	. "github.com/onsi/ginkgo/v2" //revive:disable:dot-imports
+	. "github.com/onsi/gomega"    //revive:disable:dot-imports
+
+	//revive:disable-next-line:dot-imports
+	. "github.com/openstack-k8s-operators/lib-common/modules/common/test/helpers"
 
 	"github.com/google/uuid"
 	networkv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	. "github.com/openstack-k8s-operators/lib-common/modules/common/test/helpers"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/util"
+	mariadbv1 "github.com/openstack-k8s-operators/mariadb-operator/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"

--- a/test/functional/suite_test.go
+++ b/test/functional/suite_test.go
@@ -27,8 +27,8 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo/v2" //revive:disable:dot-imports
+	. "github.com/onsi/gomega"    //revive:disable:dot-imports
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"


### PR DESCRIPTION
* removed unused func params
* ignore revive dot-imports rule on ginkgo and gomega as dot import
there is the recommended practice
* various small style fixes found by the linter
