### PR TITLE
style: Flip if-else order where it saves indent

### DIFF
--- a/controllers/neutronapi_controller.go
+++ b/controllers/neutronapi_controller.go
@@ -1022,9 +1022,7 @@ func (r *NeutronAPIReconciler) reconcileNormal(ctx context.Context, instance *ne
 		}
 
 		instance.Status.NetworkAttachments = networkAttachmentStatus
-		if networkReady {
-			instance.Status.Conditions.MarkTrue(condition.NetworkAttachmentsReadyCondition, condition.NetworkAttachmentsReadyMessage)
-		} else {
+		if !networkReady {
 			err := fmt.Errorf("not all pods have interfaces with ips as configured in NetworkAttachments: %s", instance.Spec.NetworkAttachments)
 			instance.Status.Conditions.Set(condition.FalseCondition(
 				condition.NetworkAttachmentsReadyCondition,
@@ -1035,6 +1033,7 @@ func (r *NeutronAPIReconciler) reconcileNormal(ctx context.Context, instance *ne
 
 			return ctrl.Result{}, err
 		}
+		instance.Status.Conditions.MarkTrue(condition.NetworkAttachmentsReadyCondition, condition.NetworkAttachmentsReadyMessage)
 
 		if instance.Status.ReadyCount == *instance.Spec.Replicas {
 			instance.Status.Conditions.MarkTrue(


### PR DESCRIPTION
As per [1], we should avoid unnecessary indents in these cases.

```
Try to keep the normal code path at a minimal indentation, and indent
the error handling, dealing with it first.
```

1: https://go.dev/wiki/CodeReviewComments