### PR TITLE
Add missing bits for DefaultConfigOverwrite

### DIFF
--- a/api/bases/neutron.openstack.org_neutronapis.yaml
+++ b/api/bases/neutron.openstack.org_neutronapis.yaml
@@ -72,10 +72,8 @@ spec:
               defaultConfigOverwrite:
                 additionalProperties:
                   type: string
-                description: 'ConfigOverwrite - interface to overwrite default config
-                  files like e.g. logging.conf or policy.json. But can also be used
-                  to add additional files. Those get added to the service config dir
-                  in /etc/<service> . TODO: -> implement'
+                description: DefaultConfigOverwrite - interface to overwrite default
+                  config files like policy.yaml
                 type: object
               extraMounts:
                 description: ExtraMounts containing conf files

--- a/api/v1beta1/neutronapi_types.go
+++ b/api/v1beta1/neutronapi_types.go
@@ -109,9 +109,7 @@ type NeutronAPISpecCore struct {
 	CustomServiceConfig string `json:"customServiceConfig,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// ConfigOverwrite - interface to overwrite default config files like e.g. logging.conf or policy.json.
-	// But can also be used to add additional files. Those get added to the service config dir in /etc/<service> .
-	// TODO: -> implement
+	// DefaultConfigOverwrite - interface to overwrite default config files like policy.yaml
 	DefaultConfigOverwrite map[string]string `json:"defaultConfigOverwrite,omitempty"`
 
 	// +kubebuilder:validation:Optional

--- a/api/v1beta1/neutronapi_webhook.go
+++ b/api/v1beta1/neutronapi_webhook.go
@@ -119,6 +119,8 @@ func (r *NeutronAPISpecCore) ValidateCreate(basePath *field.Path) field.ErrorLis
 	// validate the service override key is valid
 	allErrs = append(allErrs, service.ValidateRoutedOverrides(basePath.Child("override").Child("service"), r.Override.Service)...)
 
+	allErrs = append(allErrs, ValidateDefaultConfigOverwrite(basePath, r.DefaultConfigOverwrite)...)
+
 	return allErrs
 }
 
@@ -156,6 +158,8 @@ func (spec *NeutronAPISpecCore) ValidateUpdate(old NeutronAPISpecCore, basePath 
 
 	// validate the service override key is valid
 	allErrs = append(allErrs, service.ValidateRoutedOverrides(basePath.Child("override").Child("service"), spec.Override.Service)...)
+	// validate the defaultConfigOverwrite is valid
+	allErrs = append(allErrs, ValidateDefaultConfigOverwrite(basePath, spec.DefaultConfigOverwrite)...)
 
 	return allErrs
 }
@@ -176,4 +180,24 @@ func (spec *NeutronAPISpecCore) GetDefaultRouteAnnotations() (annotations map[st
 	return map[string]string{
 		"haproxy.router.openshift.io/timeout": neutronAPIDefaults.NeutronAPIRouteTimeout,
 	}
+}
+
+func ValidateDefaultConfigOverwrite(
+	basePath *field.Path,
+	validateConfigOverwrite map[string]string,
+) field.ErrorList {
+	var errors field.ErrorList
+	for requested := range validateConfigOverwrite {
+		if requested != "policy.yaml" {
+			errors = append(
+				errors,
+				field.Invalid(
+					basePath.Child("defaultConfigOverwrite"),
+					requested,
+					"Only the following keys are valid: policy.yaml",
+				),
+			)
+		}
+	}
+	return errors
 }

--- a/config/crd/bases/neutron.openstack.org_neutronapis.yaml
+++ b/config/crd/bases/neutron.openstack.org_neutronapis.yaml
@@ -72,10 +72,8 @@ spec:
               defaultConfigOverwrite:
                 additionalProperties:
                   type: string
-                description: 'ConfigOverwrite - interface to overwrite default config
-                  files like e.g. logging.conf or policy.json. But can also be used
-                  to add additional files. Those get added to the service config dir
-                  in /etc/<service> . TODO: -> implement'
+                description: DefaultConfigOverwrite - interface to overwrite default
+                  config files like policy.yaml
                 type: object
               extraMounts:
                 description: ExtraMounts containing conf files

--- a/controllers/neutronapi_controller.go
+++ b/controllers/neutronapi_controller.go
@@ -1409,7 +1409,6 @@ func (r *NeutronAPIReconciler) ensureExternalDhcpAgentSecret(
 // generateServiceSecrets - create secrets which service configuration
 // TODO(ihar) we may want to split generation of config for db-sync and for neutronapi main pod, which
 // would allow the operator to proceed with db-sync without waiting for other configuration values
-// TODO add DefaultConfigOverwrite
 func (r *NeutronAPIReconciler) generateServiceSecrets(
 	ctx context.Context,
 	h *helper.Helper,
@@ -1443,10 +1442,9 @@ func (r *NeutronAPIReconciler) generateServiceSecrets(
 		tlsCfg = &tls.Service{}
 	}
 	// customData hold any customization for the service.
-	// 02-neutron-custom.conf is going to /etc/<service>.conf.d
-	// 01-neutron.conf is going to /etc/<service>.conf.d such that it gets loaded before custom one
-	// all other files get placed into /etc/<service> to allow overwrite of e.g. logging.conf or policy.json
-	// TODO: make sure custom.conf can not be overwritten
+	// 02-neutron-custom.conf is going to /etc/<service>/<service>.conf.d
+	// 01-neutron.conf is going to /etc/<service>/<service>.conf.d such that it gets loaded before custom one
+	// all other files get placed into /etc/<service> to allow overwrite of e.g. policy.yaml
 	customData := map[string]string{
 		"02-neutron-custom.conf": instance.Spec.CustomServiceConfig,
 		"my.cnf":                 db.GetDatabaseClientConfig(tlsCfg), //(mschuppert) for now just get the default my.cnf

--- a/templates/neutronapi/config/01-neutron.conf
+++ b/templates/neutronapi/config/01-neutron.conf
@@ -99,5 +99,6 @@ memcache_servers={{ .MemcachedServers }}
 tls_enabled={{ .MemcachedTLS }}
 
 [oslo_policy]
+policy_file = /etc/neutron/policy.yaml
 enforce_scope = True
 enforce_new_defaults = True

--- a/templates/neutronapi/config/neutron-api-config.json
+++ b/templates/neutronapi/config/neutron-api-config.json
@@ -14,6 +14,13 @@
       "perm": "0640"
     },
     {
+      "source": "/var/lib/config-data/default/policy.yaml",
+      "dest": "/etc/neutron/policy.yaml",
+      "owner": "root:neutron",
+      "perm": "0640",
+      "optional": true
+    },
+    {
       "source": "/var/lib/config-data/default/my.cnf",
       "dest": "/etc/my.cnf",
       "owner": "neutron",


### PR DESCRIPTION
The input passed to DefaultConfigOverwrite was not pushed to correct location where neutron api will use those.

Also limited the use of this parameter by webhook just to provide custom policy.yaml, can be extended if we need to support other files later. It follows same patter as placement and nova operator.

We already have "ExtraMounts" parameter which can be used to push arbitary files/directory in neutron-api pod.

Closes-Issue: [OSPRH-4298](https://issues.redhat.com//browse/OSPRH-4298)