### PR TITLE
Add required csv annotations. Remove deprecated

### DIFF
--- a/config/manifests/bases/neutron-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/neutron-operator.clusterserviceversion.yaml
@@ -6,8 +6,12 @@ metadata:
     capabilities: Basic Install
     features.operators.openshift.io/disconnected: "true"
     features.operators.openshift.io/fips-compliant: "true"
+    features.operators.openshift.io/proxy-aware: "false"
+    features.operators.openshift.io/tls-profiles: "false"
+    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
     operatorframework.io/suggested-namespace: openstack
-    operators.openshift.io/infrastructure-features: '["disconnected"]'
     operators.operatorframework.io/operator-type: non-standalone
   name: neutron-operator.v0.0.0
   namespace: placeholder


### PR DESCRIPTION
Removing:
`operators.openshift.io/infrastructure-features: ["disconnected"]` is deprecated starting with OpenShift 4.14
The `features.operators.openshift.io/disconnected: "true"` annotation is already present as its replacament

Adding newly required csv annotations. Set to "false" to indicate this operator does not support them

Implements: https://issues.redhat.com/browse/OSPRH-7921