### PR TITLE
Use verifySecret to check for the expected password selector

### DIFF
--- a/test/functional/neutronapi_controller_test.go
+++ b/test/functional/neutronapi_controller_test.go
@@ -206,7 +206,8 @@ var _ = Describe("NeutronAPI controller", func() {
 					Namespace: namespace,
 				},
 				Data: map[string][]byte{
-					"transport_url": []byte("rabbit://user@svc:1234"),
+					"NeutronPassword": []byte("12345678"),
+					"transport_url":   []byte("rabbit://user@svc:1234"),
 				},
 			}
 			Expect(k8sClient.Create(ctx, secret)).Should(Succeed())
@@ -303,7 +304,8 @@ var _ = Describe("NeutronAPI controller", func() {
 					Namespace: namespace,
 				},
 				Data: map[string][]byte{
-					"transport_url": []byte("rabbit://user@svc:1234"),
+					"NeutronPassword": []byte("12345678"),
+					"transport_url":   []byte("rabbit://user@svc:1234"),
 				},
 			}
 			Expect(k8sClient.Create(ctx, secret)).Should(Succeed())
@@ -1293,7 +1295,8 @@ var _ = Describe("NeutronAPI controller", func() {
 					Namespace: GetNeutronAPI(neutronAPIName).Namespace,
 				},
 				Data: map[string][]byte{
-					"transport_url": []byte("rabbit://user@svc:1234"),
+					"NeutronPassword": []byte("12345678"),
+					"transport_url":   []byte("rabbit://user@svc:1234"),
 				},
 			}
 			Expect(k8sClient.Create(ctx, secret)).Should(Succeed())


### PR DESCRIPTION
Use verifySecret to check for the specific password selector

Before this change the operator would trigger pod restart on any change in the secret. This is because the operator was looking at the overall hash of the secret. With this change, we only hash the secret data for the operator's password selector. This was most noticeable with the osp-secret which hosts multiple passwords for openstack operators. 

This PR also updates transportURL secret reconciliation to look for the `transport_url` password selector to stay consistent. However, the issue of pods restarting with secret update was not observed with transport url secret since we use a unique transport url secret for each operator. 

JIRA: [OSPRH-7992](https://issues.redhat.com//browse/OSPRH-7992)