### PR TITLE
Run neutron httpd sidecar container using NeutronUID

### DIFF
--- a/pkg/neutronapi/scc.go
+++ b/pkg/neutronapi/scc.go
@@ -1,28 +1,20 @@
 package neutronapi
 
-import corev1 "k8s.io/api/core/v1"
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
+)
 
 func getNeutronSecurityContext() *corev1.SecurityContext {
-	trueVal := true
-	runAsUser := int64(NeutronUID)
-	runAsGroup := int64(NeutronGID)
 
 	return &corev1.SecurityContext{
-		RunAsUser:    &runAsUser,
-		RunAsGroup:   &runAsGroup,
-		RunAsNonRoot: &trueVal,
+		RunAsUser:    ptr.To(NeutronUID),
+		RunAsGroup:   ptr.To(NeutronGID),
+		RunAsNonRoot: ptr.To(true),
 		Capabilities: &corev1.Capabilities{
 			Drop: []corev1.Capability{
 				"MKNOD",
 			},
 		},
-	}
-}
-
-func getNeutronHttpdSecurityContext() *corev1.SecurityContext {
-	runAsUser := int64(0)
-
-	return &corev1.SecurityContext{
-		RunAsUser: &runAsUser,
 	}
 }

--- a/pkg/neutronapi/volumes.go
+++ b/pkg/neutronapi/volumes.go
@@ -60,25 +60,20 @@ func GetVolumeMounts(serviceName string, extraVol []neutronv1beta1.NeutronExtraV
 	}
 	return res
 
-} // GetHttpdVolumeMount - Returns the VolumeMounts used by the httpd sidecar
+}
+
+// GetHttpdVolumeMount - Returns the VolumeMounts used by the httpd sidecar
 func GetHttpdVolumeMount() []corev1.VolumeMount {
 	return []corev1.VolumeMount{
 		{
 			Name:      "httpd-config",
-			MountPath: "/etc/httpd/conf/httpd.conf",
-			SubPath:   "httpd.conf",
+			MountPath: "/var/lib/config-data/default",
 			ReadOnly:  true,
 		},
 		{
-			Name:      "httpd-config",
-			MountPath: "/etc/httpd/conf.d/10-neutron.conf",
-			SubPath:   "10-neutron-httpd.conf",
-			ReadOnly:  true,
-		},
-		{
-			Name:      "httpd-config",
-			MountPath: "/etc/httpd/conf.d/ssl.conf",
-			SubPath:   "ssl.conf",
+			Name:      "config",
+			MountPath: "/var/lib/kolla/config_files/config.json",
+			SubPath:   "neutron-httpd-config.json",
 			ReadOnly:  true,
 		},
 	}

--- a/templates/neutronapi/config/neutron-api-config.json
+++ b/templates/neutronapi/config/neutron-api-config.json
@@ -29,7 +29,7 @@
     {
       "source": "/var/lib/config-data/tls/certs/*",
       "dest": "/etc/pki/tls/certs/",
-      "owner": "root:neutron",
+      "owner": "neutron:neutron",
       "perm": "0640",
       "optional": true,
       "merge": true
@@ -37,7 +37,7 @@
     {
       "source": "/var/lib/config-data/tls/private/*",
       "dest": "/etc/pki/tls/private/",
-      "owner": "root:neutron",
+      "owner": "neutron:neutron",
       "perm": "0640",
       "optional": true,
       "merge": true

--- a/templates/neutronapi/config/neutron-httpd-config.json
+++ b/templates/neutronapi/config/neutron-httpd-config.json
@@ -1,0 +1,49 @@
+{
+    "command": "/usr/sbin/httpd -DFOREGROUND",
+    "config_files": [
+      {
+        "source": "/var/lib/config-data/tls/certs/*",
+        "dest": "/etc/pki/tls/certs/",
+        "owner": "neutron:neutron",
+        "perm": "0640",
+        "optional": true,
+        "merge": true
+      },
+      {
+        "source": "/var/lib/config-data/tls/private/*",
+        "dest": "/etc/pki/tls/private/",
+        "owner": "neutron:neutron",
+        "perm": "0640",
+        "optional": true,
+        "merge": true
+      },
+      {
+        "source": "/var/lib/config-data/default/httpd.conf",
+        "dest": "/etc/httpd/conf/httpd.conf",
+        "owner": "neutron:apache",
+        "optional": true,
+        "perm": "0644"
+      },
+      {
+        "source": "/var/lib/config-data/default/10-neutron-httpd.conf",
+        "dest": "/etc/httpd/conf.d/10-neutron.conf",
+        "owner": "neutron:apache",
+        "optional": true,
+        "perm": "0644"
+      },
+      {
+        "source": "/var/lib/config-data/default/ssl.conf",
+        "dest": "/etc/httpd/conf.d/ssl.conf",
+        "owner": "neutron:apache",
+        "optional": true,
+        "perm": "0644"
+      }
+    ],
+    "permissions": [
+        {
+            "path": "/etc/httpd/run",
+            "owner": "neutron:apache",
+            "recurse": true
+        }
+    ]
+}

--- a/templates/neutronapi/httpd/httpd.conf
+++ b/templates/neutronapi/httpd/httpd.conf
@@ -20,5 +20,6 @@ LogFormat "%{X-Forwarded-For}i %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-A
 SetEnvIf X-Forwarded-For "^.*\..*\..*\..*" forwarded
 CustomLog /dev/stdout combined env=!forwarded
 CustomLog /dev/stdout proxy env=forwarded
+ErrorLog /dev/stdout
 
 Include conf.d/10-neutron.conf

--- a/test/functional/neutronapi_controller_test.go
+++ b/test/functional/neutronapi_controller_test.go
@@ -869,7 +869,7 @@ var _ = Describe("NeutronAPI controller", func() {
 			nHttpdProxyContainer := deployment.Spec.Template.Spec.Containers[1]
 			Expect(nHttpdProxyContainer.LivenessProbe.HTTPGet.Port.IntVal).To(Equal(int32(9696)))
 			Expect(nHttpdProxyContainer.ReadinessProbe.HTTPGet.Port.IntVal).To(Equal(int32(9696)))
-			Expect(nHttpdProxyContainer.VolumeMounts).To(HaveLen(3))
+			Expect(nHttpdProxyContainer.VolumeMounts).To(HaveLen(2))
 			Expect(nHttpdProxyContainer.Image).To(Equal(util.GetEnvVar("RELATED_IMAGE_NEUTRON_API_IMAGE_URL_DEFAULT", neutronv1.NeutronAPIContainerImage)))
 		})
 	})

--- a/test/kuttl/common/assert_sample_deployment.yaml
+++ b/test/kuttl/common/assert_sample_deployment.yaml
@@ -86,7 +86,10 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: FallbackToLogsOnError
       - command:
-        - /usr/sbin/httpd
+        - /bin/bash
+        args:
+        - -c
+        - /usr/local/bin/kolla_start
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -111,7 +114,7 @@ spec:
           timeoutSeconds: 30
         resources: {}
         securityContext:
-          runAsUser: 0
+          runAsUser: 42435
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: FallbackToLogsOnError
       schedulerName: default-scheduler

--- a/test/kuttl/tests/neutron_tls/01-assert.yaml
+++ b/test/kuttl/tests/neutron_tls/01-assert.yaml
@@ -47,22 +47,16 @@ spec:
           readOnly: true
           subPath: tls-ca-bundle.pem
       - args:
-        - -DFOREGROUND
-        command:
-        - /usr/sbin/httpd
+        - -c
+        - /usr/local/bin/kolla_start
         volumeMounts:
-        - mountPath: /etc/httpd/conf/httpd.conf
+        - mountPath: /var/lib/config-data/default
           name: httpd-config
           readOnly: true
-          subPath: httpd.conf
-        - mountPath: /etc/httpd/conf.d/10-neutron.conf
-          name: httpd-config
+        - mountPath: /var/lib/kolla/config_files/config.json
+          name: config
           readOnly: true
-          subPath: 10-neutron-httpd.conf
-        - mountPath: /etc/httpd/conf.d/ssl.conf
-          name: httpd-config
-          readOnly: true
-          subPath: ssl.conf
+          subPath: neutron-httpd-config.json
         - mountPath: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
           name: combined-ca-bundle
           readOnly: true


### PR DESCRIPTION
This patch moves the `httpd` sidecar container under `kolla` management and by doing this we are able to not run it as root anymore, but use the same `NeutronUID`/`NeutronGID` provided for the `NeutronAPI` service.

Part of the conversation is tracked in Jira [1].

Jira: https://issues.redhat.com/browse/OSPRH-10290

[1] https://issues.redhat.com/browse/OSPRH-2240