### PR TITLE
Do not allow arbitary hostPath mounts via spec.extraMounts

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -235,7 +235,6 @@ rules:
   - security.openshift.io
   resourceNames:
   - anyuid
-  - hostmount-anyuid
   resources:
   - securitycontextconstraints
   verbs:

--- a/controllers/neutronapi_controller.go
+++ b/controllers/neutronapi_controller.go
@@ -102,7 +102,7 @@ type NeutronAPIReconciler struct {
 // +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=roles,verbs=get;list;watch;create;update;patch
 // +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=rolebindings,verbs=get;list;watch;create;update;patch
 // service account permissions that are needed to grant permission to the above
-// +kubebuilder:rbac:groups="security.openshift.io",resourceNames=anyuid;hostmount-anyuid,resources=securitycontextconstraints,verbs=use
+// +kubebuilder:rbac:groups="security.openshift.io",resourceNames=anyuid,resources=securitycontextconstraints,verbs=use
 // +kubebuilder:rbac:groups="",resources=pods,verbs=create;delete;get;list;patch;update;watch;patch
 
 // Reconcile - neutron api
@@ -763,7 +763,7 @@ func (r *NeutronAPIReconciler) reconcileNormal(ctx context.Context, instance *ne
 	rbacRules := []rbacv1.PolicyRule{
 		{
 			APIGroups:     []string{"security.openshift.io"},
-			ResourceNames: []string{"anyuid", "hostmount-anyuid"},
+			ResourceNames: []string{"anyuid"},
 			Resources:     []string{"securitycontextconstraints"},
 			Verbs:         []string{"use"},
 		},


### PR DESCRIPTION
We are not using hostmount-anyuid scc, but having
it added in neutron rbac role was allowing
arbitary hostPath volume mounts via spec.extraMounts.

Removing hostmount-anyuid scc in order to not allow arbitary hostPath volume mounts and avoid unnecessary security hole[1].

[1] https://kubernetes.io/docs/concepts/storage/volumes/#hostpath
Related-Issue: OSPRH-10288
Closes-Issue: OSPRH-4297