### PR TITLE
Fix pagination links returned by neutron-server in non-TLS deployments

### DIFF
--- a/templates/neutronapi/httpd/10-neutron-httpd.conf
+++ b/templates/neutronapi/httpd/10-neutron-httpd.conf
@@ -10,7 +10,11 @@
 
   ## Request header rules
   ## as per http://httpd.apache.org/docs/2.2/mod/mod_headers.html#requestheader
+{{- if $vhost.TLS }}
   RequestHeader set X-Forwarded-Proto "https"
+{{- else }}
+  RequestHeader set X-Forwarded-Proto "http"
+{{- end }}
 
   ## Proxy rules
   ProxyRequests Off


### PR DESCRIPTION
Neutron server returns links to the "next" and "previous" page of results when pagination is requested by client.
In the neutron-httpd container configuration there was an issue that "X-Forwarded-Proto" header was setting "https" protocol always, no matter if TLS was enabled in the deployment or not. It caused issues when TLS was disabled as client was doing request to the "http://" endoint and got in response "https://" links to "next" and "prev" pages.

This patch fixes this issue by setting correct protocol for both cases: TLS and non-TLS.

Closes-bug: [OSPRH-10632](https://issues.redhat.com//browse/OSPRH-10632)