### PR TITLE
Change default value of the 'tenant_network_types' option

### DIFF
--- a/templates/neutronapi/config/01-neutron.conf
+++ b/templates/neutronapi/config/01-neutron.conf
@@ -23,7 +23,7 @@ mysql_wsrep_sync_wait = 1
 [ml2]
 mechanism_drivers = {{ .Ml2MechanismDrivers }}
 type_drivers = local,flat,vlan,geneve,vxlan
-tenant_network_types = geneve,vxlan,vlan,flat
+tenant_network_types = geneve
 extension_drivers = qos,port_security,dns_domain_ports
 
 [ml2_type_geneve]


### PR DESCRIPTION
As we discussed on Slack and team meeting, it is enough to set only 'geneve' tunnel network type as tenant_network_types so that Neutron will be by default automatically trying to allocate tenant network segments only of the 'geneve' type.
Of course this value can be overwritten through the customServiceConfig provided by the Neutron CRD.

Closes: #[OSPRH-10781](https://issues.redhat.com//browse/OSPRH-10781)