### PR TITLE
Improve automated support for local webhooks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -362,12 +362,12 @@ operator-lint: gowork ## Runs operator-lint
 # The configure_local_webhook.sh script below will remove any OLM webhooks
 # for the operator and also scale its deployment replicas down to 0 so that
 # the operator can run locally.
-# Make sure to cleanup the webhook configuration for local testing by running
-# ./hack/clean_local_webhook.sh before deploying with OLM again.
+# We will attempt to catch SIGINT/SIGTERM and clean up the local webhooks,
+# but it may be necessary to manually run ./hack/clean_local_webhook.sh
+# before deploying with OLM again for other untrappable signals.
 SKIP_CERT ?=false
 .PHONY: run-with-webhook
 run-with-webhook: export METRICS_PORT?=8080
 run-with-webhook: export HEALTH_PORT?=8081
 run-with-webhook: manifests generate fmt vet ## Run a controller from your host.
-	/bin/bash hack/configure_local_webhook.sh
-	go run ./main.go -metrics-bind-address ":$(METRICS_PORT)" -health-probe-bind-address ":$(HEALTH_PORT)"
+	/bin/bash hack/run_with_local_webhook.sh

--- a/hack/run_with_local_webhook.sh
+++ b/hack/run_with_local_webhook.sh
@@ -1,4 +1,16 @@
 #!/bin/bash
+
+# Define a cleanup function
+cleanup() {
+    echo "Caught signal, cleaning up local webhooks..."
+    ./hack/clean_local_webhook.sh
+    exit 0
+}
+
+# Set trap to catch SIGINT and SIGTERM
+trap cleanup SIGINT SIGTERM
+
+#!/bin/bash
 set -ex
 
 TMPDIR=${TMPDIR:-"/tmp/k8s-webhook-server/serving-certs"}
@@ -8,29 +20,28 @@ FIREWALL_ZONE=${FIREWALL_ZONE:-"libvirt"}
 
 #Open 9443
 if command -v firewall-cmd &> /dev/null; then
-    sudo firewall-cmd --zone=${FIREWALL_ZONE} --add-port=9443/tcp
+    sudo firewall-cmd --zone="${FIREWALL_ZONE}" --add-port=9443/tcp
     sudo firewall-cmd --runtime-to-permanent
 fi
 
 # Generate the certs and the ca bundle
 if [ "$SKIP_CERT" = false ] ; then
-    mkdir -p ${TMPDIR}
-    rm -rf ${TMPDIR}/* || true
+    mkdir -p "${TMPDIR}"
+    rm -rf "${TMPDIR}"/* || true
 
     openssl req -newkey rsa:2048 -days 3650 -nodes -x509 \
         -subj "/CN=${HOSTNAME}" \
         -addext "subjectAltName = IP:${CRC_IP}" \
-        -keyout ${TMPDIR}/tls.key \
-        -out ${TMPDIR}/tls.crt
+        -keyout "${TMPDIR}"/tls.key \
+        -out "${TMPDIR}"/tls.crt
 
-    cat ${TMPDIR}/tls.crt ${TMPDIR}/tls.key | base64 -w 0 > ${TMPDIR}/bundle.pem
-
+    cat "${TMPDIR}"/tls.crt "${TMPDIR}"/tls.key | base64 -w 0 > "${TMPDIR}"/bundle.pem
 fi
 
-CA_BUNDLE=`cat ${TMPDIR}/bundle.pem`
+CA_BUNDLE=$(cat "${TMPDIR}"/bundle.pem)
 
 # Patch the webhook(s)
-cat >> ${TMPDIR}/patch_webhook_configurations.yaml <<EOF_CAT
+cat >> "${TMPDIR}"/patch_webhook_configurations.yaml <<EOF_CAT
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
@@ -88,7 +99,7 @@ webhooks:
   timeoutSeconds: 10
 EOF_CAT
 
-oc apply -n openstack -f ${TMPDIR}/patch_webhook_configurations.yaml
+oc apply -n openstack -f "${TMPDIR}"/patch_webhook_configurations.yaml
 
 # Scale-down operator deployment replicas to zero and remove OLM webhooks
 CSV_NAME="$(oc get csv -n openstack-operators -l operators.coreos.com/neutron-operator.openstack-operators -o name)"
@@ -112,3 +123,5 @@ if [ -n "${CSV_NAME}" ]; then
     oc patch "${CSV_NAME}" -n openstack-operators --type=json -p="[{'op': 'replace', 'path': '/spec/install/spec/deployments/0/spec/replicas', 'value': 0}]"
     oc patch "${CSV_NAME}" -n openstack-operators --type=json -p="[{'op': 'replace', 'path': '/spec/webhookdefinitions', 'value': []}]"
 fi
+
+go run ./main.go -metrics-bind-address ":${METRICS_PORT}" -health-probe-bind-address ":${HEALTH_PORT}"


### PR DESCRIPTION
Reworks `make run-with-webhook` target to trap `SIGINT` and `SIGTERM` so as to call `clean_local_webhook.sh` in such a scenario.  This way, a user can run the operator locally and automatically have the local webhooks removed when they finish running the operator via `ctrl+c`.