### PR TITLE
Remove vxlan config bits from the default configuration

### DIFF
--- a/templates/neutronapi/config/01-neutron.conf
+++ b/templates/neutronapi/config/01-neutron.conf
@@ -22,7 +22,7 @@ mysql_wsrep_sync_wait = 1
 {{ if eq .CorePlugin "ml2" }}
 [ml2]
 mechanism_drivers = {{ .Ml2MechanismDrivers }}
-type_drivers = local,flat,vlan,geneve,vxlan
+type_drivers = local,flat,vlan,geneve
 tenant_network_types = geneve
 extension_drivers = qos,port_security,dns_domain_ports
 
@@ -32,9 +32,6 @@ max_header_size = 38
 
 [ml2_type_vlan]
 network_vlan_ranges = datacentre
-
-[ml2_type_vxlan]
-vni_ranges = 1:65536
 
 {{ if .IsOVN }}
 [ovn]


### PR DESCRIPTION
As we don't support vxlan network type in the ML2/OVN backend in RHOSO we should not load by default vxlan type driver. This patch cleans it from the default Neutron config template.

Closes: #[OSPRH-10967](https://issues.redhat.com//browse/OSPRH-10967)