### PR TITLE
Make apache timeout configurable

### DIFF
--- a/api/bases/neutron.openstack.org_neutronapis.yaml
+++ b/api/bases/neutron.openstack.org_neutronapis.yaml
@@ -48,6 +48,11 @@ spec:
           spec:
             description: NeutronAPISpec defines the desired state of NeutronAPI
             properties:
+              apiTimeout:
+                default: 120
+                description: APITimeout for HAProxy, Apache
+                minimum: 1
+                type: integer
               containerImage:
                 description: NeutronAPI Container Image URL (will be set to environmental
                   default if empty)

--- a/api/v1beta1/neutronapi_types.go
+++ b/api/v1beta1/neutronapi_types.go
@@ -51,6 +51,12 @@ type NeutronAPISpec struct {
 // NeutronAPISpecCore -
 type NeutronAPISpecCore struct {
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=120
+	// +kubebuilder:validation:Minimum=1
+	// APITimeout for HAProxy, Apache
+	APITimeout int `json:"apiTimeout"`
+
+	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=neutron
 	// ServiceUser - optional username used for this service to register in neutron
 	ServiceUser string `json:"serviceUser"`
@@ -290,8 +296,8 @@ func (instance NeutronAPI) IsOVNEnabled() bool {
 func SetupDefaults() {
 	// Acquire environmental defaults and initialize Neutron defaults with them
 	neutronDefaults := NeutronAPIDefaults{
-		ContainerImageURL:      util.GetEnvVar("RELATED_IMAGE_NEUTRON_API_IMAGE_URL_DEFAULT", NeutronAPIContainerImage),
-		NeutronAPIRouteTimeout: "120s",
+		ContainerImageURL: util.GetEnvVar("RELATED_IMAGE_NEUTRON_API_IMAGE_URL_DEFAULT", NeutronAPIContainerImage),
+		APITimeout: 120,
 	}
 
 	SetupNeutronAPIDefaults(neutronDefaults)

--- a/config/crd/bases/neutron.openstack.org_neutronapis.yaml
+++ b/config/crd/bases/neutron.openstack.org_neutronapis.yaml
@@ -48,6 +48,11 @@ spec:
           spec:
             description: NeutronAPISpec defines the desired state of NeutronAPI
             properties:
+              apiTimeout:
+                default: 120
+                description: APITimeout for HAProxy, Apache
+                minimum: 1
+                type: integer
               containerImage:
                 description: NeutronAPI Container Image URL (will be set to environmental
                   default if empty)

--- a/controllers/neutronapi_controller.go
+++ b/controllers/neutronapi_controller.go
@@ -1547,6 +1547,7 @@ func (r *NeutronAPIReconciler) generateServiceSecrets(
 	templateParameters["MemcachedServers"] = mc.GetMemcachedServerListString()
 	templateParameters["MemcachedServersWithInet"] = mc.GetMemcachedServerListWithInetString()
 	templateParameters["MemcachedTLS"] = mc.GetMemcachedTLSSupport()
+	templateParameters["TimeOut"] = instance.Spec.APITimeout
 
 	// Other OpenStack services
 	servicePassword := string(ospSecret.Data[instance.Spec.PasswordSelectors.Service])

--- a/templates/neutronapi/httpd/10-neutron-httpd.conf
+++ b/templates/neutronapi/httpd/10-neutron-httpd.conf
@@ -3,6 +3,8 @@
 <VirtualHost *:9696>
   ServerName {{ $vhost.ServerName }}
 
+  TimeOut {{ $.TimeOut }}
+
   ## Logging
   ErrorLog /dev/stdout
   ServerSignature Off


### PR DESCRIPTION
Added a parameter 'apiTimeout' to allow customization
to the Apache timeout.
The default is set to 120s which we do set for
HAProxy timeouts currently.

To be able to change the HAProxy value based on the `apiTimeout` with
any update (and not just the first time) the code adds a custom
annotation "api.neutron.openstack.org/timeout" with the value that was
initially set, this way flags it as being set by the neutron-operator.

There will be follow up patch in openstack-operator
to utilize the method 'SetDefaultRouteAnnotations' to set
these default route annotations.

Resolves: [OSPRH-10843](https://issues.redhat.com//browse/OSPRH-10843)