### PR TITLE
Ensure nodeSelector logic is consistent for all operators

### DIFF
--- a/api/v1beta1/neutronapi_types.go
+++ b/api/v1beta1/neutronapi_types.go
@@ -101,7 +101,7 @@ type NeutronAPISpecCore struct {
 
 	// +kubebuilder:validation:Optional
 	// NodeSelector to target subset of worker nodes running this service
-	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
+	NodeSelector *map[string]string `json:"nodeSelector,omitempty"`
 
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=false
@@ -297,7 +297,7 @@ func SetupDefaults() {
 	// Acquire environmental defaults and initialize Neutron defaults with them
 	neutronDefaults := NeutronAPIDefaults{
 		ContainerImageURL: util.GetEnvVar("RELATED_IMAGE_NEUTRON_API_IMAGE_URL_DEFAULT", NeutronAPIContainerImage),
-		APITimeout: 120,
+		APITimeout:        120,
 	}
 
 	SetupNeutronAPIDefaults(neutronDefaults)

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -151,9 +151,13 @@ func (in *NeutronAPISpecCore) DeepCopyInto(out *NeutronAPISpecCore) {
 	out.PasswordSelectors = in.PasswordSelectors
 	if in.NodeSelector != nil {
 		in, out := &in.NodeSelector, &out.NodeSelector
-		*out = make(map[string]string, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
+		*out = new(map[string]string)
+		if **in != nil {
+			in, out := *in, *out
+			*out = make(map[string]string, len(*in))
+			for key, val := range *in {
+				(*out)[key] = val
+			}
 		}
 	}
 	if in.Ml2MechanismDrivers != nil {

--- a/pkg/neutronapi/dbsync.go
+++ b/pkg/neutronapi/dbsync.go
@@ -54,5 +54,10 @@ func DbSyncJob(
 			},
 		},
 	}
+
+	if cr.Spec.NodeSelector != nil {
+		job.Spec.Template.Spec.NodeSelector = *cr.Spec.NodeSelector
+	}
+
 	return job
 }

--- a/pkg/neutronapi/deployment.go
+++ b/pkg/neutronapi/deployment.go
@@ -186,8 +186,8 @@ func Deployment(
 		},
 		corev1.LabelHostname,
 	)
-	if instance.Spec.NodeSelector != nil && len(instance.Spec.NodeSelector) > 0 {
-		deployment.Spec.Template.Spec.NodeSelector = instance.Spec.NodeSelector
+	if instance.Spec.NodeSelector != nil {
+		deployment.Spec.Template.Spec.NodeSelector = *instance.Spec.NodeSelector
 	}
 
 	return deployment, nil

--- a/test/functional/neutronapi_controller_test.go
+++ b/test/functional/neutronapi_controller_test.go
@@ -67,6 +67,8 @@ func getNeutronAPIControllerSuite(ml2MechanismDrivers []string) func() {
 		var internalCertSecretName types.NamespacedName
 		var publicCertSecretName types.NamespacedName
 		var ovnDbCertSecretName types.NamespacedName
+		var neutronDeploymentName types.NamespacedName
+		var neutronDBSyncJobName types.NamespacedName
 
 		BeforeEach(func() {
 			name = fmt.Sprintf("neutron-%s", uuid.New().String())
@@ -107,6 +109,14 @@ func getNeutronAPIControllerSuite(ml2MechanismDrivers []string) func() {
 			}
 			ovnDbCertSecretName = types.NamespacedName{
 				Name:      OVNDbCertSecretName,
+				Namespace: namespace,
+			}
+			neutronDeploymentName = types.NamespacedName{
+				Name:      neutronapi.ServiceName,
+				Namespace: namespace,
+			}
+			neutronDBSyncJobName = types.NamespacedName{
+				Name:      neutronAPIName.Name + "-db-sync",
 				Namespace: namespace,
 			}
 		})
@@ -838,7 +848,7 @@ func getNeutronAPIControllerSuite(ml2MechanismDrivers []string) func() {
 			It("Should set DBReady Condition and set DatabaseHostname Status when DB is Created", func() {
 				mariadb.SimulateMariaDBAccountCompleted(types.NamespacedName{Namespace: namespace, Name: GetNeutronAPI(neutronAPIName).Spec.DatabaseAccount})
 				mariadb.SimulateMariaDBDatabaseCompleted(types.NamespacedName{Namespace: namespace, Name: neutronapi.DatabaseCRName})
-				th.SimulateJobSuccess(types.NamespacedName{Namespace: namespace, Name: neutronAPIName.Name + "-db-sync"})
+				th.SimulateJobSuccess(neutronDBSyncJobName)
 				NeutronAPI := GetNeutronAPI(neutronAPIName)
 				hostname := "hostname-for-" + NeutronAPI.Spec.DatabaseInstance + "." + namespace + ".svc"
 				Expect(NeutronAPI.Status.DatabaseHostname).To(Equal(hostname))
@@ -878,7 +888,7 @@ func getNeutronAPIControllerSuite(ml2MechanismDrivers []string) func() {
 				DeferCleanup(keystone.DeleteKeystoneAPI, keystone.CreateKeystoneAPI(namespace))
 				mariadb.SimulateMariaDBAccountCompleted(types.NamespacedName{Namespace: namespace, Name: GetNeutronAPI(neutronAPIName).Spec.DatabaseAccount})
 				mariadb.SimulateMariaDBDatabaseCompleted(types.NamespacedName{Namespace: namespace, Name: neutronapi.DatabaseCRName})
-				th.SimulateJobSuccess(types.NamespacedName{Namespace: namespace, Name: neutronAPIName.Name + "-db-sync"})
+				th.SimulateJobSuccess(neutronDBSyncJobName)
 				keystone.SimulateKeystoneServiceReady(types.NamespacedName{Namespace: namespace, Name: "neutron"})
 				keystone.SimulateKeystoneEndpointReady(types.NamespacedName{Namespace: namespace, Name: "neutron"})
 			})
@@ -975,7 +985,7 @@ func getNeutronAPIControllerSuite(ml2MechanismDrivers []string) func() {
 				DeferCleanup(th.DeleteInstance, nad)
 				mariadb.SimulateMariaDBAccountCompleted(types.NamespacedName{Namespace: namespace, Name: GetNeutronAPI(neutronAPIName).Spec.DatabaseAccount})
 				mariadb.SimulateMariaDBDatabaseCompleted(types.NamespacedName{Namespace: namespace, Name: neutronapi.DatabaseCRName})
-				th.SimulateJobSuccess(types.NamespacedName{Namespace: namespace, Name: neutronAPIName.Name + "-db-sync"})
+				th.SimulateJobSuccess(neutronDBSyncJobName)
 				keystone.SimulateKeystoneServiceReady(types.NamespacedName{Namespace: namespace, Name: "neutron"})
 				keystone.SimulateKeystoneEndpointReady(types.NamespacedName{Namespace: namespace, Name: "neutron"})
 
@@ -1019,7 +1029,7 @@ func getNeutronAPIControllerSuite(ml2MechanismDrivers []string) func() {
 				DeferCleanup(th.DeleteInstance, nad)
 				mariadb.SimulateMariaDBAccountCompleted(types.NamespacedName{Namespace: namespace, Name: GetNeutronAPI(neutronAPIName).Spec.DatabaseAccount})
 				mariadb.SimulateMariaDBDatabaseCompleted(types.NamespacedName{Namespace: namespace, Name: neutronapi.DatabaseCRName})
-				th.SimulateJobSuccess(types.NamespacedName{Namespace: namespace, Name: neutronAPIName.Name + "-db-sync"})
+				th.SimulateJobSuccess(neutronDBSyncJobName)
 				keystone.SimulateKeystoneServiceReady(types.NamespacedName{Namespace: namespace, Name: "neutron"})
 				keystone.SimulateKeystoneEndpointReady(types.NamespacedName{Namespace: namespace, Name: "neutron"})
 				deplName := types.NamespacedName{
@@ -1064,7 +1074,7 @@ func getNeutronAPIControllerSuite(ml2MechanismDrivers []string) func() {
 				DeferCleanup(th.DeleteInstance, nad)
 				mariadb.SimulateMariaDBAccountCompleted(types.NamespacedName{Namespace: namespace, Name: GetNeutronAPI(neutronAPIName).Spec.DatabaseAccount})
 				mariadb.SimulateMariaDBDatabaseCompleted(types.NamespacedName{Namespace: namespace, Name: neutronapi.DatabaseCRName})
-				th.SimulateJobSuccess(types.NamespacedName{Namespace: namespace, Name: neutronAPIName.Name + "-db-sync"})
+				th.SimulateJobSuccess(neutronDBSyncJobName)
 				keystone.SimulateKeystoneServiceReady(types.NamespacedName{Namespace: namespace, Name: "neutron"})
 				keystone.SimulateKeystoneEndpointReady(types.NamespacedName{Namespace: namespace, Name: "neutron"})
 
@@ -1132,7 +1142,7 @@ func getNeutronAPIControllerSuite(ml2MechanismDrivers []string) func() {
 				DeferCleanup(keystone.DeleteKeystoneAPI, keystone.CreateKeystoneAPI(namespace))
 				mariadb.SimulateMariaDBAccountCompleted(types.NamespacedName{Namespace: namespace, Name: GetNeutronAPI(neutronAPIName).Spec.DatabaseAccount})
 				mariadb.SimulateMariaDBTLSDatabaseCompleted(types.NamespacedName{Namespace: namespace, Name: neutronapi.Database})
-				th.SimulateJobSuccess(types.NamespacedName{Namespace: namespace, Name: neutronAPIName.Name + "-db-sync"})
+				th.SimulateJobSuccess(neutronDBSyncJobName)
 				keystone.SimulateKeystoneServiceReady(types.NamespacedName{Namespace: namespace, Name: "neutron"})
 				keystone.SimulateKeystoneEndpointReady(types.NamespacedName{Namespace: namespace, Name: "neutron"})
 			})
@@ -1320,7 +1330,7 @@ func getNeutronAPIControllerSuite(ml2MechanismDrivers []string) func() {
 				DeferCleanup(keystone.DeleteKeystoneAPI, keystone.CreateKeystoneAPI(namespace))
 				mariadb.SimulateMariaDBAccountCompleted(types.NamespacedName{Namespace: namespace, Name: GetNeutronAPI(neutronAPIName).Spec.DatabaseAccount})
 				mariadb.SimulateMariaDBDatabaseCompleted(types.NamespacedName{Namespace: namespace, Name: neutronapi.DatabaseCRName})
-				th.SimulateJobSuccess(types.NamespacedName{Namespace: namespace, Name: neutronAPIName.Name + "-db-sync"})
+				th.SimulateJobSuccess(neutronDBSyncJobName)
 				keystone.SimulateKeystoneServiceReady(types.NamespacedName{Namespace: namespace, Name: "neutron"})
 				keystone.SimulateKeystoneEndpointReady(types.NamespacedName{Namespace: namespace, Name: "neutron"})
 			})
@@ -1338,6 +1348,106 @@ func getNeutronAPIControllerSuite(ml2MechanismDrivers []string) func() {
 				Expect(endpoints).To(HaveKeyWithValue("public", "https://neutron-openstack.apps-crc.testing"))
 				Expect(endpoints).To(HaveKeyWithValue("internal", "https://neutron-internal."+neutronAPIName.Namespace+".svc:9696"))
 			})
+		})
+
+		When("A NeutronAPI is created with nodeSelector", func() {
+			BeforeEach(func() {
+				spec["nodeSelector"] = map[string]interface{}{
+					"foo": "bar",
+				}
+
+				DeferCleanup(th.DeleteInstance, CreateNeutronAPI(neutronAPIName.Namespace, neutronAPIName.Name, spec))
+				DeferCleanup(k8sClient.Delete, ctx, CreateNeutronAPISecret(namespace, SecretName))
+				DeferCleanup(
+					mariadb.DeleteDBService,
+					mariadb.CreateDBService(
+						namespace,
+						GetNeutronAPI(neutronAPIName).Spec.DatabaseInstance,
+						corev1.ServiceSpec{
+							Ports: []corev1.ServicePort{{Port: 3306}},
+						},
+					),
+				)
+				SimulateTransportURLReady(apiTransportURLName)
+				DeferCleanup(infra.DeleteMemcached, infra.CreateMemcached(namespace, "memcached", memcachedSpec))
+				infra.SimulateMemcachedReady(memcachedName)
+				DeferCleanup(DeleteOVNDBClusters, CreateOVNDBClusters(namespace))
+				DeferCleanup(keystone.DeleteKeystoneAPI, keystone.CreateKeystoneAPI(namespace))
+				mariadb.SimulateMariaDBAccountCompleted(types.NamespacedName{Namespace: namespace, Name: GetNeutronAPI(neutronAPIName).Spec.DatabaseAccount})
+				mariadb.SimulateMariaDBDatabaseCompleted(types.NamespacedName{Namespace: namespace, Name: neutronapi.DatabaseCRName})
+				th.SimulateJobSuccess(neutronDBSyncJobName)
+				keystone.SimulateKeystoneServiceReady(types.NamespacedName{Namespace: namespace, Name: "neutron"})
+				keystone.SimulateKeystoneEndpointReady(types.NamespacedName{Namespace: namespace, Name: "neutron"})
+			})
+
+			It("sets nodeSelector in resource specs", func() {
+				Eventually(func(g Gomega) {
+					g.Expect(th.GetDeployment(neutronDeploymentName).Spec.Template.Spec.NodeSelector).To(Equal(map[string]string{"foo": "bar"}))
+					g.Expect(th.GetJob(neutronDBSyncJobName).Spec.Template.Spec.NodeSelector).To(Equal(map[string]string{"foo": "bar"}))
+				}, timeout, interval).Should(Succeed())
+			})
+
+			It("updates nodeSelector in resource specs when changed", func() {
+				Eventually(func(g Gomega) {
+					g.Expect(th.GetDeployment(neutronDeploymentName).Spec.Template.Spec.NodeSelector).To(Equal(map[string]string{"foo": "bar"}))
+					g.Expect(th.GetJob(neutronDBSyncJobName).Spec.Template.Spec.NodeSelector).To(Equal(map[string]string{"foo": "bar"}))
+				}, timeout, interval).Should(Succeed())
+
+				Eventually(func(g Gomega) {
+					neutron := GetNeutronAPI(neutronAPIName)
+					newNodeSelector := map[string]string{
+						"foo2": "bar2",
+					}
+					neutron.Spec.NodeSelector = &newNodeSelector
+					g.Expect(k8sClient.Update(ctx, neutron)).Should(Succeed())
+				}, timeout, interval).Should(Succeed())
+
+				Eventually(func(g Gomega) {
+					th.SimulateJobSuccess(neutronDBSyncJobName)
+					g.Expect(th.GetDeployment(neutronDeploymentName).Spec.Template.Spec.NodeSelector).To(Equal(map[string]string{"foo2": "bar2"}))
+					g.Expect(th.GetJob(neutronDBSyncJobName).Spec.Template.Spec.NodeSelector).To(Equal(map[string]string{"foo2": "bar2"}))
+				}, timeout, interval).Should(Succeed())
+			})
+
+			It("removes nodeSelector from resource specs when cleared", func() {
+				Eventually(func(g Gomega) {
+					g.Expect(th.GetDeployment(neutronDeploymentName).Spec.Template.Spec.NodeSelector).To(Equal(map[string]string{"foo": "bar"}))
+					g.Expect(th.GetJob(neutronDBSyncJobName).Spec.Template.Spec.NodeSelector).To(Equal(map[string]string{"foo": "bar"}))
+				}, timeout, interval).Should(Succeed())
+
+				Eventually(func(g Gomega) {
+					neutron := GetNeutronAPI(neutronAPIName)
+					emptyNodeSelector := map[string]string{}
+					neutron.Spec.NodeSelector = &emptyNodeSelector
+					g.Expect(k8sClient.Update(ctx, neutron)).Should(Succeed())
+				}, timeout, interval).Should(Succeed())
+
+				Eventually(func(g Gomega) {
+					th.SimulateJobSuccess(neutronDBSyncJobName)
+					g.Expect(th.GetDeployment(neutronDeploymentName).Spec.Template.Spec.NodeSelector).To(BeNil())
+					g.Expect(th.GetJob(neutronDBSyncJobName).Spec.Template.Spec.NodeSelector).To(BeNil())
+				}, timeout, interval).Should(Succeed())
+			})
+
+			It("removes nodeSelector from resource specs when nilled", func() {
+				Eventually(func(g Gomega) {
+					g.Expect(th.GetDeployment(neutronDeploymentName).Spec.Template.Spec.NodeSelector).To(Equal(map[string]string{"foo": "bar"}))
+					g.Expect(th.GetJob(neutronDBSyncJobName).Spec.Template.Spec.NodeSelector).To(Equal(map[string]string{"foo": "bar"}))
+				}, timeout, interval).Should(Succeed())
+
+				Eventually(func(g Gomega) {
+					neutron := GetNeutronAPI(neutronAPIName)
+					neutron.Spec.NodeSelector = nil
+					g.Expect(k8sClient.Update(ctx, neutron)).Should(Succeed())
+				}, timeout, interval).Should(Succeed())
+
+				Eventually(func(g Gomega) {
+					th.SimulateJobSuccess(neutronDBSyncJobName)
+					g.Expect(th.GetDeployment(neutronDeploymentName).Spec.Template.Spec.NodeSelector).To(BeNil())
+					g.Expect(th.GetJob(neutronDBSyncJobName).Spec.Template.Spec.NodeSelector).To(BeNil())
+				}, timeout, interval).Should(Succeed())
+			})
+
 		})
 
 		// Run MariaDBAccount suite tests.  these are pre-packaged ginkgo tests
@@ -1397,16 +1507,12 @@ func getNeutronAPIControllerSuite(ml2MechanismDrivers []string) func() {
 
 				mariadb.SimulateMariaDBAccountCompleted(accountName)
 				mariadb.SimulateMariaDBDatabaseCompleted(types.NamespacedName{Namespace: namespace, Name: neutronapi.DatabaseCRName})
-				th.SimulateJobSuccess(types.NamespacedName{Namespace: namespace, Name: neutronAPIName.Name + "-db-sync"})
+				th.SimulateJobSuccess(neutronDBSyncJobName)
 				keystone.SimulateKeystoneServiceReady(types.NamespacedName{Namespace: namespace, Name: "neutron"})
 				keystone.SimulateKeystoneEndpointReady(types.NamespacedName{Namespace: namespace, Name: "neutron"})
-				deplName := types.NamespacedName{
-					Namespace: namespace,
-					Name:      "neutron",
-				}
 
 				th.SimulateDeploymentReadyWithPods(
-					deplName,
+					neutronDeploymentName,
 					map[string][]string{namespace + "/internalapi": {}},
 				)
 


### PR DESCRIPTION
nodeSelectors are not currently applied consistently across all operators.

Some do not support nodeSelectors at all - will be implemented in this series of pull requests.
Some do not apply them to every pod (jobs/cronjobs esp) - will be resolved in this series of pull requests.
Some do not apply a node selector update correctly, only when not initially set.
Some support nodeSelectors but do not inherit the default nodeSelector from the OpenstackControlPlane CR.

Jira: [OSPRH-10734](https://issues.redhat.com//browse/OSPRH-10734)