### PR TITLE
Fix default cache config for no tls

### DIFF
--- a/templates/neutronapi/config/01-neutron.conf
+++ b/templates/neutronapi/config/01-neutron.conf
@@ -90,11 +90,12 @@ lock_path = /var/lib/neutron/tmp
 [cache]
 {{if .MemcachedTLS}}
 backend = dogpile.cache.pymemcache
+memcache_servers = {{ .MemcachedServers }}
 {{else}}
 backend = dogpile.cache.memcached
+memcache_servers = {{ .MemcachedServersWithInet }}
 {{end}}
 enabled=true
-memcache_servers={{ .MemcachedServers }}
 tls_enabled={{ .MemcachedTLS }}
 
 [oslo_policy]


### PR DESCRIPTION
When env is deployed with tls disabled, cache config was wrong as "dogpile.cache.memcached" backend requires inet[6] prefixes for memcache_servers setting while it was set without the prefix. with IPv4 issue not observed as "inet" is default prefix, this patch fixes it by setting [cache]/memcache_servers based on tls config.

Resolves: OSPRH-12223
Related-Issue: OSPRH-12221