### PR TITLE
[httpd] Set X-Forwarded-Proto only if empty

### DIFF
--- a/templates/neutronapi/httpd/10-neutron-httpd.conf
+++ b/templates/neutronapi/httpd/10-neutron-httpd.conf
@@ -13,9 +13,9 @@
   ## Request header rules
   ## as per http://httpd.apache.org/docs/2.2/mod/mod_headers.html#requestheader
 {{- if $vhost.TLS }}
-  RequestHeader set X-Forwarded-Proto "https"
+  RequestHeader setIfEmpty X-Forwarded-Proto "https"
 {{- else }}
-  RequestHeader set X-Forwarded-Proto "http"
+  RequestHeader setIfEmpty X-Forwarded-Proto "http"
 {{- end }}
 
   ## Proxy rules


### PR DESCRIPTION
ocp routes add these header based on ssl config,
let's honor that and set this request header only in httpd config only if it's empty.

Noticed this issue with pagination tests when deployed control plane with tls.podlevel=false and tls.ingress=true.

Related-Issue: [OSPRH-12374](https://issues.redhat.com//browse/OSPRH-12374)