### PR TITLE
Enable ovn_emit_need_to_frag by default

### DIFF
--- a/templates/neutronapi/config/01-neutron.conf
+++ b/templates/neutronapi/config/01-neutron.conf
@@ -39,6 +39,7 @@ ovn_nb_connection = {{ .NBConnection }}
 ovn_sb_connection = {{ .SBConnection }}
 ovn_metadata_enabled = True
 enable_distributed_floating_ip=True
+ovn_emit_need_to_frag = True
 {{- if .OVNDB_TLS }}
 ovn_nb_private_key = /etc/pki/tls/private/ovndb.key
 ovn_nb_certificate = /etc/pki/tls/certs/ovndb.crt


### PR DESCRIPTION
The default switched in neutron master already with [1]. Setting it in operator default config to get it applied in older releases like antelope where [1] is not available.

[1] https://review.opendev.org/c/openstack/neutron/+/930608

Related-Issue: #[OSPRH-10684](https://issues.redhat.com//browse/OSPRH-10684)