### PR TITLE
[kuttl] Use relative path to scripts

### DIFF
--- a/test/kuttl/tests/change_neutron_config/02-assert.yaml
+++ b/test/kuttl/tests/change_neutron_config/02-assert.yaml
@@ -3,7 +3,7 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
 commands:
   - script: |
-        $NEUTRON_KUTTL_DIR/../common/scripts/check_debug_in_neutron_pod_logs.sh
+        ../../common/scripts/check_debug_in_neutron_pod_logs.sh
   - script: |
         neutron_pod=$(oc get pods -n $NAMESPACE -l service=neutron --field-selector=status.phase=Running -o name|head -1)
         oc rsh -n $NAMESPACE ${neutron_pod} crudini --get /etc/neutron/neutron.conf.d/testcm.conf DEFAULT api_workers

--- a/test/kuttl/tests/change_neutron_config/03-assert.yaml
+++ b/test/kuttl/tests/change_neutron_config/03-assert.yaml
@@ -3,5 +3,5 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
 commands:
   - script: |
-      $NEUTRON_KUTTL_DIR/../common/scripts/check_debug_in_neutron_pod_logs.sh
+      ../../common/scripts/check_debug_in_neutron_pod_logs.sh
       test $? -ne 0


### PR DESCRIPTION
Couple of tests were relying on NEUTRON_KUTTL_DIR to be set, let's avoid the dep on extra var and use relative path to the test.

Alternative to https://github.com/openstack-k8s-operators/install_yamls/pull/915