### PR TITLE
Use quay hosted kube-rbac-proxy image

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -16,7 +16,7 @@ spec:
         # capabilities:
         #   drop:
         #     - "ALL"
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.0
+        image: quay.io/openstack-k8s-operators/kube-rbac-proxy:v0.16.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"


### PR DESCRIPTION
The image gcr.io/kubebuilder/kube-rbac-proxy is deprecated and will become unavailable. Sometime from early 2025 the GCR will go away.
The plan is to update the project to use the new WithAuthenticationAndAuthorization from kubebuilder. Until we are able to do that, use our own hosted kube-rbac-proxy image.

Jira: [OSPRH-14114](https://issues.redhat.com//browse/OSPRH-14114)