### PR TITLE
Improve topology testing coverage

### DIFF
--- a/test/functional/base_test.go
+++ b/test/functional/base_test.go
@@ -21,16 +21,16 @@ import (
 
 	"github.com/google/uuid"
 	. "github.com/onsi/gomega" //revive:disable:dot-imports
+	topologyv1 "github.com/openstack-k8s-operators/infra-operator/apis/topology/v1beta1"
+	condition "github.com/openstack-k8s-operators/lib-common/modules/common/condition"
+	neutronv1 "github.com/openstack-k8s-operators/neutron-operator/api/v1beta1"
+	"github.com/openstack-k8s-operators/neutron-operator/pkg/neutronapi"
+	ovnv1 "github.com/openstack-k8s-operators/ovn-operator/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	condition "github.com/openstack-k8s-operators/lib-common/modules/common/condition"
-	neutronv1 "github.com/openstack-k8s-operators/neutron-operator/api/v1beta1"
-	"github.com/openstack-k8s-operators/neutron-operator/pkg/neutronapi"
-	ovnv1 "github.com/openstack-k8s-operators/ovn-operator/api/v1beta1"
 )
 
 const (
@@ -189,7 +189,7 @@ func CreateNeutronAPISecret(namespace string, name string) *corev1.Secret {
 // want to avoid by default
 // 2. Usually a topologySpreadConstraints is used to take care about
 // multi AZ, which is not applicable in this context
-func GetSampleTopologySpec() map[string]interface{} {
+func GetSampleTopologySpec(label string) (map[string]interface{}, []corev1.TopologySpreadConstraint) {
 	// Build the topology Spec
 	topologySpec := map[string]interface{}{
 		"topologySpreadConstraints": []map[string]interface{}{
@@ -199,17 +199,35 @@ func GetSampleTopologySpec() map[string]interface{} {
 				"whenUnsatisfiable": "ScheduleAnyway",
 				"labelSelector": map[string]interface{}{
 					"matchLabels": map[string]interface{}{
-						"service": neutronapi.ServiceName,
+						"service":   neutronapi.ServiceName,
+						"component": label,
 					},
 				},
 			},
 		},
 	}
-	return topologySpec
+	// Build the topologyObj representation
+	topologySpecObj := []corev1.TopologySpreadConstraint{
+		{
+			MaxSkew:           1,
+			TopologyKey:       corev1.LabelHostname,
+			WhenUnsatisfiable: corev1.ScheduleAnyway,
+			LabelSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"service":   neutronapi.ServiceName,
+					"component": label,
+				},
+			},
+		},
+	}
+	return topologySpec, topologySpecObj
 }
 
 // CreateTopology - Creates a Topology CR based on the spec passed as input
-func CreateTopology(topology types.NamespacedName, spec map[string]interface{}) client.Object {
+func CreateTopology(
+	topology types.NamespacedName,
+	spec map[string]interface{},
+) (client.Object, topologyv1.TopoRef) {
 	raw := map[string]interface{}{
 		"apiVersion": "topology.openstack.org/v1beta1",
 		"kind":       "Topology",
@@ -219,5 +237,20 @@ func CreateTopology(topology types.NamespacedName, spec map[string]interface{}) 
 		},
 		"spec": spec,
 	}
-	return th.CreateUnstructured(raw)
+	// other than creating the topology based on the raw spec, we return the
+	// TopoRef that can be referenced
+	topologyRef := topologyv1.TopoRef{
+		Name:      topology.Name,
+		Namespace: topology.Namespace,
+	}
+	return th.CreateUnstructured(raw), topologyRef
+}
+
+// GetTopology - Returns the referenced Topology
+func GetTopology(name types.NamespacedName) *topologyv1.Topology {
+	instance := &topologyv1.Topology{}
+	Eventually(func(g Gomega) {
+		g.Expect(k8sClient.Get(ctx, name, instance)).Should(Succeed())
+	}, timeout, interval).Should(Succeed())
+	return instance
 }


### PR DESCRIPTION
This patch improves our topology testing with several enhancements and extends the `topologyRef` tests:
   - `finalizer` verification for each sub component that references a topology
   - Updated `Topologies` to support `component-specific` label selectors

This work completes the topology validation improvements initiated in [1], addressing the remaining open points.

Jira: https://issues.redhat.com/browse/OSPRH-15220

[1] nova-operator#941