### PR TITLE
Change memcache to use memcache_pool driver

### DIFF
--- a/templates/neutronapi/config/01-neutron.conf
+++ b/templates/neutronapi/config/01-neutron.conf
@@ -92,18 +92,21 @@ lock_path = /var/lib/neutron/tmp
 
 [cache]
 {{if .MemcachedTLS}}
-backend = dogpile.cache.pymemcache
+backend = oslo_cache.memcache_pool
 memcache_servers = {{ .MemcachedServers }}
-enable_retry_client = true
-retry_attempts = 2
-retry_delay = 0
+memcache_socket_timeout = 0.5
+memcache_pool_connection_get_timeout = 1
+# workaround to force bmemcache driver
+memcache_sasl_enable = true
+# this is needed to override the default set by the operator
+enable_retry_client = false
 {{else}}
 backend = dogpile.cache.memcached
 memcache_servers = {{ .MemcachedServersWithInet }}
-memcache_dead_retry = 10
 {{end}}
 enabled=true
 tls_enabled={{ .MemcachedTLS }}
+memcache_dead_retry = 30
 
 [oslo_policy]
 policy_file = /etc/neutron/policy.yaml

--- a/test/functional/neutronapi_controller_test.go
+++ b/test/functional/neutronapi_controller_test.go
@@ -717,7 +717,7 @@ func getNeutronAPIControllerSuite(ml2MechanismDrivers []string) func() {
 				neutronCfg := string(th.GetSecret(secret).Data["01-neutron.conf"])
 				if memcacheInstance.GetMemcachedTLSSupport() {
 					Expect(neutronCfg).Should(
-						ContainSubstring("backend = dogpile.cache.pymemcache"))
+						ContainSubstring("backend = oslo_cache.memcache_pool"))
 					Expect(neutronCfg).Should(
 						ContainSubstring(fmt.Sprintf("memcache_servers = %s", memcacheInstance.GetMemcachedServerListString())))
 				} else {


### PR DESCRIPTION
In HA tests it was identified that pymemcache backend does not recover/fail over to the next memcache instance when one goes away unexpected. Using memcache_pool with bmemcache does failover properly.

The memcache_sasl_enable=true is a workaround to force oslo.cache to switch to the bmemcache driver, which is the only driver in memcache_pool supporting tls+fips.

Jira: [OSPRH-16651](https://issues.redhat.com//browse/OSPRH-16651)

Co-outhored-by: Luca Miccini <lmiccini@redhat.com>