### PR TITLE
[CI] Disable config drive for ovn metadata coverage

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -26,6 +26,9 @@
       - ^tests?/kuttl/.*$
       - ^zuul.d/(?!(project)).*\.yaml
     vars:
+      cifmw_edpm_deploy_nova_compute_extra_config: |
+        [DEFAULT]
+        force_config_drive = false
       cifmw_tempest_container: openstack-tempest-all
       cifmw_run_test_role: tempest
       cifmw_tempest_tempestconf_profile:


### PR DESCRIPTION
Config drive is enabled by default, in order to have more coverage for ovn metadata, disabling config drive.