### PR TITLE
Sort map keys for deterministic iteration

### DIFF
--- a/controllers/neutronapi_controller.go
+++ b/controllers/neutronapi_controller.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -675,7 +676,17 @@ func (r *NeutronAPIReconciler) reconcileInit(
 	}
 	apiEndpoints := make(map[string]string)
 
-	for endpointType, data := range neutronEndpoints {
+	// Sort endpoint types for deterministic iteration
+	var endpointTypes []service.Endpoint
+	for endpointType := range neutronEndpoints {
+		endpointTypes = append(endpointTypes, endpointType)
+	}
+	sort.SliceStable(endpointTypes, func(i, j int) bool {
+		return string(endpointTypes[i]) < string(endpointTypes[j])
+	})
+
+	for _, endpointType := range endpointTypes {
+		data := neutronEndpoints[endpointType]
 		endpointTypeStr := string(endpointType)
 		endpointName := neutronapi.ServiceName + "-" + endpointTypeStr
 


### PR DESCRIPTION
The map ordering is random in golang[1], using
sort to make this deterministic and avoid any
reconcilation loops

[1] https://go.dev/blog/maps#iteration-order

Resolves: [OSPRH-17883](https://issues.redhat.com//browse/OSPRH-17883)