### PR TITLE
Add support for the neutron-fwaas plugin

### DIFF
--- a/api/bases/neutron.openstack.org_neutronapis.yaml
+++ b/api/bases/neutron.openstack.org_neutronapis.yaml
@@ -89,6 +89,10 @@ spec:
                 description: DefaultConfigOverwrite - interface to overwrite default
                   config files like policy.yaml
                 type: object
+              enableFwaas:
+                default: false
+                description: EnableFwaas - enable NeutronFwaas service plugin
+                type: boolean
               extraMounts:
                 description: ExtraMounts containing conf files
                 items:

--- a/api/v1beta1/neutronapi_types.go
+++ b/api/v1beta1/neutronapi_types.go
@@ -156,6 +156,11 @@ type NeutronAPISpecCore struct {
 	// TopologyRef to apply the Topology defined by the associated CR referenced
 	// by name
 	TopologyRef *topologyv1.TopoRef `json:"topologyRef,omitempty"`
+
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=false
+	// EnableFwaas - enable NeutronFwaas service plugin
+	EnableFwaas bool `json:"enableFwaas"`
 }
 
 type NeutronApiTLS struct {

--- a/config/crd/bases/neutron.openstack.org_neutronapis.yaml
+++ b/config/crd/bases/neutron.openstack.org_neutronapis.yaml
@@ -89,6 +89,10 @@ spec:
                 description: DefaultConfigOverwrite - interface to overwrite default
                   config files like policy.yaml
                 type: object
+              enableFwaas:
+                default: false
+                description: EnableFwaas - enable NeutronFwaas service plugin
+                type: boolean
               extraMounts:
                 description: ExtraMounts containing conf files
                 items:

--- a/controllers/neutronapi_controller.go
+++ b/controllers/neutronapi_controller.go
@@ -1732,6 +1732,8 @@ func (r *NeutronAPIReconciler) generateServiceSecrets(
 		templateParameters["OVNDB_TLS"] = instance.Spec.TLS.Ovn.Enabled()
 	}
 
+	templateParameters["EnableFwaas"] = instance.Spec.EnableFwaas
+
 	// create httpd  vhost template parameters
 	httpdVhostConfig := map[string]interface{}{}
 	for _, endpt := range []service.Endpoint{service.EndpointInternal, service.EndpointPublic} {

--- a/templates/neutronapi/config/01-neutron.conf
+++ b/templates/neutronapi/config/01-neutron.conf
@@ -4,9 +4,17 @@ bind_port = 9697
 transport_url={{ .TransportURL }}
 core_plugin = {{ .CorePlugin }}
 {{ if .IsOVN }}
+  {{ if .EnableFwaas }}
+service_plugins = qos,ovn-router,trunk,segments,port_forwarding,log,firewall_v2
+  {{ else }}
 service_plugins = qos,ovn-router,trunk,segments,port_forwarding,log
+  {{ end }}
 {{ else }}
+  {{ if .EnableFwaas }}
+service_plugins = qos,trunk,segments,port_forwarding,log,firewall_v2
+  {{ else }}
 service_plugins = qos,trunk,segments,port_forwarding,log
+  {{ end }}
 {{ end }}
 dns_domain = openstackgate.local
 dhcp_agent_notification = false
@@ -119,3 +127,8 @@ memcache_dead_retry = 30
 policy_file = /etc/neutron/policy.yaml
 enforce_scope = True
 enforce_new_defaults = True
+
+{{ if and .EnableFwaas .IsOVN }}
+[service_providers]
+service_provider = FIREWALL_V2:fwaas_db:neutron_fwaas.services.firewall.service_drivers.ovn.firewall_l3_driver.OVNFwaasDriver:default
+{{ end }}


### PR DESCRIPTION
This patch adds "enableFwaas" flag to the Neutron CRD. Setting this flag to `True` will enable `firewall_v2` service plugin and configure OVN service provider for the FIREWALL_V2 resource if OVN mechanism driver is used.

Closes: #[OSPRH-15214](https://issues.redhat.com//browse/OSPRH-15214)