### PR TITLE
Enable dns_records_ovn_owned by default.

### DIFF
--- a/templates/neutronapi/config/01-neutron.conf
+++ b/templates/neutronapi/config/01-neutron.conf
@@ -40,6 +40,7 @@ ovn_sb_connection = {{ .SBConnection }}
 ovn_metadata_enabled = True
 enable_distributed_floating_ip=True
 ovn_emit_need_to_frag = True
+dns_records_ovn_owned = True
 {{- if .OVNDB_TLS }}
 ovn_nb_private_key = /etc/pki/tls/private/ovndb.key
 ovn_nb_certificate = /etc/pki/tls/certs/ovndb.crt


### PR DESCRIPTION
This patch enables dns_records_ovn_owned when OVN is enabled by default to address slow DNS look up time.

Closes: #[OSPRH-10207](https://issues.redhat.com//browse/OSPRH-10207)