### PR TITLE
[OSPRH-20360] Improve consistency of condition severity usage

### DIFF
--- a/test/functional/neutronapi_controller_test.go
+++ b/test/functional/neutronapi_controller_test.go
@@ -1178,7 +1178,7 @@ func getNeutronAPIControllerSuite(ml2MechanismDrivers []string) func() {
 					ConditionGetterFunc(NeutronAPIConditionGetter),
 					condition.NetworkAttachmentsReadyCondition,
 					corev1.ConditionFalse,
-					condition.RequestedReason,
+					condition.ErrorReason,
 					"NetworkAttachment resources missing: internalapi",
 				)
 			})


### PR DESCRIPTION
Use consistent condition severity across repeated patterns found in our operators, and otherwise use an appropriate severity for conditions unique to each operator.

Jira: https://issues.redhat.com/browse/OSPRH-20360

Co-authored-by: Claude (Anthropic) [claude@anthropic.com](mailto:claude@anthropic.com)