### PR TITLE
Remove go.work before container build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,10 @@ WORKDIR $REMOTE_SOURCE_DIR/$REMOTE_SOURCE_SUBDIR
 USER root
 RUN mkdir -p ${DEST_ROOT}/usr/local/bin/
 
+# Remove go.work - not needed for the build and may reference a Go version
+# from the CI environment that is higher than the build image provides
+RUN rm -f go.work go.work.sum
+
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
 RUN if [ ! -f $CACHITO_ENV_FILE ]; then go mod download ; fi

--- a/test/kuttl/tests/notifications/01-assert.yaml
+++ b/test/kuttl/tests/notifications/01-assert.yaml
@@ -3,4 +3,4 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
 commands:
   - script: |
-      oc wait --for=condition=ReconcileSuccess rabbitmqcluster.rabbitmq.com rabbitmq-br -n $NAMESPACE --timeout=180s
+      oc wait --for=condition=Ready rabbitmq.rabbitmq.openstack.org rabbitmq-br -n $NAMESPACE --timeout=180s

--- a/test/kuttl/tests/notifications/01-create-rabbit-br.yaml
+++ b/test/kuttl/tests/notifications/01-create-rabbit-br.yaml
@@ -1,21 +1,11 @@
 # Create rabbitmq-broadcaster for notifications and enable notifications
-apiVersion: rabbitmq.com/v1beta1
-kind: RabbitmqCluster
+apiVersion: rabbitmq.openstack.org/v1beta1
+kind: RabbitMq
 metadata:
   name: rabbitmq-br
 spec:
-  override:
-    statefulSet:
-      spec:
-        template:
-          spec:
-            securityContext: {}
-            containers: []
-            initContainers:
-            - name: setup-container
-              securityContext: {}
-  persistence:
-    storage: 1Gi
+  replicas: 1
+  storageClass: local-storage
   resources:
     limits:
       cpu: "0.5"


### PR DESCRIPTION
The go.work file is generated by the CI environment which may have a higher Go version than the build image (go-toolset). This causes build failures when go.work references a Go version that the build image does not provide. Since the Dockerfile builds a single module, go.work is not needed and can be safely removed before building.