### PR TITLE
Add application credential finalizer management

### DIFF
--- a/api/bases/neutron.openstack.org_neutronapis.yaml
+++ b/api/bases/neutron.openstack.org_neutronapis.yaml
@@ -1607,6 +1607,13 @@ spec:
           status:
             description: NeutronAPIStatus defines the observed state of NeutronAPI
             properties:
+              applicationCredentialSecret:
+                description: |-
+                  ApplicationCredentialSecret - the AC secret NeutronAPI is currently
+                  consuming and protecting with the openstack.org/neutronapi-ac-consumer
+                  finalizer. Tracked so the controller can remove its finalizer from the
+                  old secret when the openstack-operator rotates the reference.
+                type: string
               conditions:
                 description: Conditions
                 items:

--- a/api/v1beta1/neutronapi_types.go
+++ b/api/v1beta1/neutronapi_types.go
@@ -177,6 +177,7 @@ type NeutronAPISpecCore struct {
 	// An empty value "" leaves the notification drivers unconfigured and emitting no notifications at all.
 	// Avoid colocating it with RabbitMqClusterName used for RPC.
 	NotificationsBusInstance *string `json:"notificationsBusInstance,omitempty" deprecated:"notificationsBus.cluster"`
+
 }
 
 type NeutronApiTLS struct {
@@ -236,6 +237,12 @@ type NeutronAPIStatus struct {
 
 	// NetworkAttachments status of the deployment pods
 	NetworkAttachments map[string][]string `json:"networkAttachments,omitempty"`
+
+	// ApplicationCredentialSecret - the AC secret NeutronAPI is currently
+	// consuming and protecting with the openstack.org/neutronapi-ac-consumer
+	// finalizer. Tracked so the controller can remove its finalizer from the
+	// old secret when the openstack-operator rotates the reference.
+	ApplicationCredentialSecret string `json:"applicationCredentialSecret,omitempty"`
 
 	// ObservedGeneration - the most recent generation observed for this
 	// service. If the observed generation is less than the spec generation,

--- a/config/crd/bases/neutron.openstack.org_neutronapis.yaml
+++ b/config/crd/bases/neutron.openstack.org_neutronapis.yaml
@@ -1607,6 +1607,13 @@ spec:
           status:
             description: NeutronAPIStatus defines the observed state of NeutronAPI
             properties:
+              applicationCredentialSecret:
+                description: |-
+                  ApplicationCredentialSecret - the AC secret NeutronAPI is currently
+                  consuming and protecting with the openstack.org/neutronapi-ac-consumer
+                  finalizer. Tracked so the controller can remove its finalizer from the
+                  old secret when the openstack-operator rotates the reference.
+                type: string
               conditions:
                 description: Conditions
                 items:

--- a/internal/controller/neutronapi_controller.go
+++ b/internal/controller/neutronapi_controller.go
@@ -492,6 +492,19 @@ func (r *NeutronAPIReconciler) reconcileDelete(ctx context.Context, instance *ne
 	); err != nil {
 		return ctrlResult, err
 	}
+	// Remove consumer finalizer from AC secrets NeutronAPI was consuming.
+	// Check both status and spec to handle the edge case where the reconciler
+	// crashed after adding the finalizer but before updating the status.
+	for _, secretName := range []string{
+		instance.Status.ApplicationCredentialSecret,
+		instance.Spec.Auth.ApplicationCredentialSecret,
+	} {
+		if err := keystonev1.RemoveACSecretConsumerFinalizer(ctx, helper, instance.Namespace,
+			secretName, neutronapi.ACConsumerFinalizer); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
 	// Service is deleted so remove the finalizer.
 	controllerutil.RemoveFinalizer(instance, helper.GetFinalizer())
 	Log.Info("Reconciled Service delete successfully")
@@ -647,6 +660,24 @@ func (r *NeutronAPIReconciler) reconcileInit(
 	}
 
 	// Create Secrets - end
+
+	// Add consumer finalizer to the new AC secret early, before deployment.
+	// The old secret's finalizer is removed later (after all services deploy)
+	// so that rapid rotations don't revoke a credential still in use by pods.
+	if instance.Spec.Auth.ApplicationCredentialSecret != "" {
+		if err := keystonev1.ManageACSecretFinalizer(ctx, helper, instance.Namespace,
+			instance.Spec.Auth.ApplicationCredentialSecret,
+			"",
+			neutronapi.ACConsumerFinalizer); err != nil {
+			instance.Status.Conditions.Set(condition.FalseCondition(
+				condition.ServiceConfigReadyCondition,
+				condition.ErrorReason,
+				condition.SeverityWarning,
+				condition.ServiceConfigReadyErrorMessage,
+				err.Error()))
+			return ctrl.Result{}, err
+		}
+	}
 
 	instance.Status.Conditions.MarkTrue(condition.ServiceConfigReadyCondition, condition.ServiceConfigReadyMessage)
 
@@ -1376,6 +1407,25 @@ func (r *NeutronAPIReconciler) reconcileNormal(ctx context.Context, instance *ne
 			return ctrl.Result{}, err
 		}
 	}
+	// Manage the old AC secret's finalizer and status tracking.
+	// On rotation (old != new), only remove the old secret's finalizer after
+	// all sub-services are ready with the new credentials. This prevents
+	// premature revocation during rapid rotations.
+	isRotation := instance.Status.ApplicationCredentialSecret != "" && instance.Status.ApplicationCredentialSecret != instance.Spec.Auth.ApplicationCredentialSecret
+
+	if isRotation {
+		allServicesReady := instance.Status.Conditions.AllSubConditionIsTrue()
+		if allServicesReady {
+			if err := keystonev1.RemoveACSecretConsumerFinalizer(ctx, helper, instance.Namespace,
+				instance.Status.ApplicationCredentialSecret, neutronapi.ACConsumerFinalizer); err != nil {
+				return ctrl.Result{}, err
+			}
+			instance.Status.ApplicationCredentialSecret = instance.Spec.Auth.ApplicationCredentialSecret
+		}
+	} else {
+		instance.Status.ApplicationCredentialSecret = instance.Spec.Auth.ApplicationCredentialSecret
+	}
+
 	// We reached the end of the Reconcile, update the Ready condition based on
 	// the sub conditions
 	if instance.Status.Conditions.AllSubConditionIsTrue() {

--- a/internal/neutronapi/const.go
+++ b/internal/neutronapi/const.go
@@ -50,6 +50,9 @@ const (
 
 	// NeutronDhcpAgentSecretKey is the key in external Secret for Neutron DHCP Agent with agent config
 	NeutronDhcpAgentSecretKey = "10-neutron-dhcp.conf"
+
+	// ACConsumerFinalizer is added to AC secrets that neutron is actively consuming
+	ACConsumerFinalizer = "openstack.org/neutronapi-ac-consumer"
 )
 
 // DbsyncPropagation keeps track of the DBSync Service Propagation Type

--- a/test/functional/neutronapi_controller_test.go
+++ b/test/functional/neutronapi_controller_test.go
@@ -2202,6 +2202,178 @@ func getNeutronAPIControllerSuite(ml2MechanismDrivers []string) func() {
 				}, timeout, interval).Should(Succeed())
 			})
 		})
+
+		When("ApplicationCredential consumer finalizer is managed", func() {
+			var acSecretName string
+
+			BeforeEach(func() {
+				acSecretName = "ac-neutron-a1b2c-secret" //nolint:gosec // G101
+				secret := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: namespace,
+						Name:      acSecretName,
+					},
+					Data: map[string][]byte{
+						keystonev1.ACIDSecretKey:     []byte("a1b2ctest-ac-id"),
+						keystonev1.ACSecretSecretKey: []byte("test-ac-secret"),
+					},
+				}
+				DeferCleanup(k8sClient.Delete, ctx, secret)
+				Expect(k8sClient.Create(ctx, secret)).To(Succeed())
+
+				spec["auth"] = map[string]any{
+					"applicationCredentialSecret": acSecretName,
+				}
+
+				DeferCleanup(th.DeleteInstance, CreateNeutronAPI(neutronAPIName.Namespace, neutronAPIName.Name, spec))
+				DeferCleanup(k8sClient.Delete, ctx, CreateNeutronAPISecret(namespace, SecretName))
+				DeferCleanup(infra.DeleteMemcached, infra.CreateMemcached(namespace, "memcached", memcachedSpec))
+				infra.SimulateMemcachedReady(memcachedName)
+				DeferCleanup(
+					mariadb.DeleteDBService,
+					mariadb.CreateDBService(
+						namespace,
+						GetNeutronAPI(neutronAPIName).Spec.DatabaseInstance,
+						corev1.ServiceSpec{
+							Ports: []corev1.ServicePort{{Port: 3306}},
+						},
+					),
+				)
+				SimulateTransportURLReady(apiTransportURLName)
+				mariadb.SimulateMariaDBAccountCompleted(types.NamespacedName{Namespace: namespace, Name: GetNeutronAPI(neutronAPIName).Spec.DatabaseAccount})
+				mariadb.SimulateMariaDBDatabaseCompleted(types.NamespacedName{Namespace: namespace, Name: neutronapi.DatabaseCRName})
+
+				if isOVNEnabled {
+					DeferCleanup(DeleteOVNDBClusters, CreateOVNDBClusters(namespace))
+				}
+				DeferCleanup(keystone.DeleteKeystoneAPI, keystone.CreateKeystoneAPI(namespace))
+			})
+
+			It("should add the consumer finalizer to the AC secret", func() {
+				Eventually(func(g Gomega) {
+					secret := th.GetSecret(types.NamespacedName{
+						Namespace: namespace,
+						Name:      acSecretName,
+					})
+					g.Expect(secret.Finalizers).To(
+						ContainElement(neutronapi.ACConsumerFinalizer))
+				}, timeout, interval).Should(Succeed())
+			})
+
+			It("should track the consumed AC secret in status", func() {
+				th.SimulateJobSuccess(neutronDBSyncJobName)
+				keystone.SimulateKeystoneServiceReady(types.NamespacedName{
+					Namespace: namespace,
+					Name:      "neutron",
+				})
+				keystone.SimulateKeystoneEndpointReady(types.NamespacedName{
+					Namespace: namespace,
+					Name:      "neutron",
+				})
+				Eventually(func(g Gomega) {
+					n := GetNeutronAPI(neutronAPIName)
+					g.Expect(n.Status.ApplicationCredentialSecret).To(Equal(acSecretName))
+				}, timeout, interval).Should(Succeed())
+			})
+
+			It("should move the finalizer from the old to the new secret on rotation", func() {
+				Eventually(func(g Gomega) {
+					secret := th.GetSecret(types.NamespacedName{
+						Namespace: namespace,
+						Name:      acSecretName,
+					})
+					g.Expect(secret.Finalizers).To(
+						ContainElement(neutronapi.ACConsumerFinalizer))
+				}, timeout, interval).Should(Succeed())
+
+				th.SimulateJobSuccess(neutronDBSyncJobName)
+				th.SimulateDeploymentReplicaReady(types.NamespacedName{
+					Namespace: namespace,
+					Name:      "neutron",
+				})
+				keystone.SimulateKeystoneServiceReady(types.NamespacedName{
+					Namespace: namespace,
+					Name:      "neutron",
+				})
+				keystone.SimulateKeystoneEndpointReady(types.NamespacedName{
+					Namespace: namespace,
+					Name:      "neutron",
+				})
+				Eventually(func(g Gomega) {
+					n := GetNeutronAPI(neutronAPIName)
+					g.Expect(n.Status.Conditions.IsTrue(condition.ReadyCondition)).To(BeTrue())
+				}, timeout, interval).Should(Succeed())
+
+				newACSecretName := "ac-neutron-x9y8z-secret" //nolint:gosec // G101
+				newSecret := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: namespace,
+						Name:      newACSecretName,
+					},
+					Data: map[string][]byte{
+						keystonev1.ACIDSecretKey:     []byte("x9y8zrotated-ac-id"),
+						keystonev1.ACSecretSecretKey: []byte("rotated-ac-secret"),
+					},
+				}
+				DeferCleanup(k8sClient.Delete, ctx, newSecret)
+				Expect(k8sClient.Create(ctx, newSecret)).To(Succeed())
+
+				Eventually(func(g Gomega) {
+					n := GetNeutronAPI(neutronAPIName)
+					n.Spec.Auth.ApplicationCredentialSecret = newACSecretName
+					g.Expect(k8sClient.Update(ctx, n)).Should(Succeed())
+				}, timeout, interval).Should(Succeed())
+
+				Eventually(func(g Gomega) {
+					secret := th.GetSecret(types.NamespacedName{
+						Namespace: namespace,
+						Name:      newACSecretName,
+					})
+					g.Expect(secret.Finalizers).To(
+						ContainElement(neutronapi.ACConsumerFinalizer))
+				}, timeout, interval).Should(Succeed())
+
+				Eventually(func(g Gomega) {
+					th.SimulateDeploymentReplicaReady(types.NamespacedName{
+						Namespace: namespace,
+						Name:      "neutron",
+					})
+					secret := th.GetSecret(types.NamespacedName{
+						Namespace: namespace,
+						Name:      acSecretName,
+					})
+					g.Expect(secret.Finalizers).NotTo(
+						ContainElement(neutronapi.ACConsumerFinalizer))
+				}, timeout, interval).Should(Succeed())
+
+				Eventually(func(g Gomega) {
+					n := GetNeutronAPI(neutronAPIName)
+					g.Expect(n.Status.ApplicationCredentialSecret).To(Equal(newACSecretName))
+				}, timeout, interval).Should(Succeed())
+			})
+
+			It("should remove the consumer finalizer from AC secret on CR deletion", func() {
+				Eventually(func(g Gomega) {
+					secret := th.GetSecret(types.NamespacedName{
+						Namespace: namespace,
+						Name:      acSecretName,
+					})
+					g.Expect(secret.Finalizers).To(
+						ContainElement(neutronapi.ACConsumerFinalizer))
+				}, timeout, interval).Should(Succeed())
+
+				th.DeleteInstance(GetNeutronAPI(neutronAPIName))
+
+				Eventually(func(g Gomega) {
+					secret := th.GetSecret(types.NamespacedName{
+						Namespace: namespace,
+						Name:      acSecretName,
+					})
+					g.Expect(secret.Finalizers).NotTo(
+						ContainElement(neutronapi.ACConsumerFinalizer))
+				}, timeout, interval).Should(Succeed())
+			})
+		})
 	}
 }
 


### PR DESCRIPTION
Jira: [OSPRH-29269](https://redhat.atlassian.net/browse/OSPRH-29269)

Application Credential dev-doc: https://github.com/openstack-k8s-operators/dev-docs/blob/main/application_credentials.md

* Tracks the active AC secret name in `Status.ApplicationCredentialSecret`
* Add `openstack.org/neutronapi-ac-consumer` finalizer to the AC secret after service config is rendered
* On AC rotation, move the finalizer from the old secret to the new one
* On CR deletion, remove the consumer finalizer from the AC secret before cleaning up the CR

This ensures that the keystone-operator cannot revoke a rotated AC secret while Neutron is still consuming it.

```
2026-04-28T11:54:58.578Z	INFO	Controllers.NeutronAPI	Added consumer finalizer	{"controller": "neutronapi", "controllerGroup": "neutron.openstack.org", "controllerKind": "NeutronAPI", "NeutronAPI": {"name":"neutron","namespace":"openstack"}, "namespace": "openstack", "name": "neutron", "reconcileID": "c8bf38d1-2f9c-4fe9-88ba-1f6f2a701983", "object": "ac-neutron-0dc46-secret", "finalizer": "openstack.org/neutronapi-ac-consumer"}
2026-04-28T11:54:58.589Z	INFO	Controllers.NeutronAPI	Removed consumer finalizer	{"controller": "neutronapi", "controllerGroup": "neutron.openstack.org", "controllerKind": "NeutronAPI", "NeutronAPI": {"name":"neutron","namespace":"openstack"}, "namespace": "openstack", "name": "neutron", "reconcileID": "c8bf38d1-2f9c-4fe9-88ba-1f6f2a701983", "object": "ac-neutron-86ca8-secret", "finalizer": "openstack.org/neutronapi-ac-consumer"}
```

Depends-On: https://github.com/openstack-k8s-operators/keystone-operator/pull/685

Assisted-by: Claude Opus 4.6 [noreply@anthropic.com](mailto:noreply@anthropic.com)