### PR TITLE
Custom httpd configuration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,11 @@ spec:
 The data defined in `/var/lib/neutron/third_party/partner1` will be mounted
 to the resulting neutronAPI pod.
 
+## Customize httpd
+
+- [Customize httpd](config/samples/httpd-overrides): inject custom httpd
+  configuration through extraMounts interface
+
 # Design
 *TBD*
 

--- a/config/samples/httpd-overrides/README.md
+++ b/config/samples/httpd-overrides/README.md
@@ -1,0 +1,121 @@
+# Neutron HTTPD Configuration Overrides
+
+The neutron-operator provides mechanisms to customize the Apache HTTPD server
+configuration through the use of custom configuration files. This feature
+leverages the
+[ExtraMounts](https://github.com/openstack-k8s-operators/dev-docs/blob/main/extra_mounts.md)
+functionality to mount custom HTTPD configuration files into the Neutron
+deployment.
+
+## How It Works
+
+1. **Custom Configuration Files**: Create HTTPD configuration files with your
+   custom settings
+2. **ConfigMap**: Create ConfigMaps from files containing the overrides
+3. **OpenStackControlPlane Patch**: Patch the control plane to mount the
+   generated ConfigMap into Neutron containers. The HTTPD configuration
+   automatically includes files mounted to `/etc/httpd/conf_custom/*.conf`
+
+
+### Step 1: Create Custom HTTPD Configuration
+
+Create your custom HTTPD configuration file(s). As a best practice the filename
+could start with the `httpd_custom_` prefix, but all `*.conf` files mounted to
+`/etc/httpd/conf_custom/` are automatically included by the `IncludeOptional`
+directive in the base `httpd` configuration.
+
+Example (`httpd_custom_connection.conf`):
+```apache
+# Custom connection settings for Neutron
+MaxKeepAliveRequests 200
+KeepAliveTimeout 15
+```
+
+### Step 2. Create a ConfigMap
+
+Create a Kubernetes `ConfigMap` containing your custom configuration files:
+
+```bash
+oc create configmap httpd-overrides --from-file=httpd_custom_connection.conf
+```
+
+It is possible to add multiple configuration files containing dedicated
+configuration directives:
+
+```bash
+oc create configmap httpd-overrides \
+  --from-file=httpd_custom_connection.conf \
+  --from-file=httpd_custom_security.conf \
+  --from-file=httpd_custom_logging.conf
+```
+
+The following example is based on a single customization file and demonstrates
+how to set custom `MaxKeepAliveRequests` and `KeepAliveTimeout` parameters.
+
+### Step 3: Configure ExtraMounts in the OpenStackControlPlane
+
+Update your `OpenStackControlPlane` resource to include the custom HTTPD
+configuration files using `extraMounts`. The simplest approach is to mount
+the entire ConfigMap to the target `/etc/httpd/conf_custom` mount point:
+
+```yaml
+apiVersion: core.openstack.org/v1beta1
+kind: OpenStackControlPlane
+metadata:
+  name: openstack
+spec:
+  neutron:
+    template:
+      extraMounts:
+      - extraVol:
+        - extraVolType: httpd-overrides
+          mounts:
+          - mountPath: /etc/httpd/conf_custom
+            name: httpd-overrides
+            readOnly: true
+          volumes:
+          - configMap:
+              name: httpd-overrides
+            name: httpd-overrides
+```
+
+## Common Use Cases
+
+- **Connection Tuning**: Adjust keep-alive settings, connection limits, etc.
+- **Security Headers**: Add custom security headers or configurations
+- **Logging**: Customize Apache logging configuration
+- **Performance Tuning**: Adjust worker processes, thread limits, etc.
+
+## Verification
+
+After deploying your custom `HTTPD` configuration, you can verify that the
+settings have been properly applied:
+
+### 1. Find the Neutron Pod
+
+First, identify the running Neutron pod:
+
+```bash
+$ oc get pods -l service=neutron
+```
+
+### 2. Verify Configuration Loading
+
+Connect to the Neutron Pod and check that your custom configuration has been
+loaded:
+
+```bash
+# Replace <neutron-pod-name> with the actual pod name from step 1
+oc rsh -c neutron-httpd <neutron-pod-name>
+# Inside the pod, dump the HTTPD configuration and check for your custom settings
+httpd -D DUMP_CONFIG
+```
+
+### 3. Additional Verification Commands
+
+You can also verify other aspects of the configuration:
+
+```bash
+# Check all loaded configuration files
+$ httpd -D DUMP_INCLUDES
+```

--- a/config/samples/httpd-overrides/httpd_custom_connection.conf
+++ b/config/samples/httpd-overrides/httpd_custom_connection.conf
@@ -1,0 +1,5 @@
+# Custom connection settings for Neutron HTTPD
+# This file demonstrates how to override default connection parameters
+# for Apache HTTPD serving Neutron API requests
+MaxKeepAliveRequests 200
+KeepAliveTimeout 15

--- a/config/samples/httpd-overrides/httpd_overrides.yaml
+++ b/config/samples/httpd-overrides/httpd_overrides.yaml
@@ -1,0 +1,18 @@
+apiVersion: core.openstack.org/v1beta1
+kind: OpenStackControlPlane
+metadata:
+  name: openstack
+spec:
+  neutron:
+    template:
+      extraMounts:
+        - extraVol:
+            - extraVolType: httpd-overrides
+              mounts:
+                - mountPath: /etc/httpd/conf_custom
+                  name: httpd-overrides
+                  readOnly: true
+              volumes:
+                - configMap:
+                    name: httpd-overrides
+                  name: httpd-overrides

--- a/config/samples/httpd-overrides/kustomization.yaml
+++ b/config/samples/httpd-overrides/kustomization.yaml
@@ -1,0 +1,20 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - https://raw.githubusercontent.com/openstack-k8s-operators/openstack-operator/main/config/samples/core_v1beta1_openstackcontrolplane_galera_network_isolation.yaml
+
+patches:
+  - target:
+      kind: OpenStackControlPlane
+      name: .*
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: openstack
+  - path: httpd_overrides.yaml
+
+configMapGenerator:
+- files:
+  - ./httpd_custom_connection.conf
+  name: httpd-overrides

--- a/templates/neutronapi/httpd/10-neutron-httpd.conf
+++ b/templates/neutronapi/httpd/10-neutron-httpd.conf
@@ -32,5 +32,8 @@
   SSLCertificateFile      "{{ $vhost.SSLCertificateFile }}"
   SSLCertificateKeyFile   "{{ $vhost.SSLCertificateKeyFile }}"
 {{- end }}
+
+  IncludeOptional conf_custom/*.conf
+
 </VirtualHost>
 {{ end }}


### PR DESCRIPTION
Introduce a new sample demonstrating how to customize `httpd` conf using `extraMounts`. 
This approach leverages the `extraMounts` feature to inject custom configuration files loaded from `/etc/httpd/conf_custom`, enabling users to modify `httpd` settings without introducing new API parameters to the operator.
This follows the pattern already present in storage operators (e.g. https://github.com/openstack-k8s-operators/cinder-operator/pull/600)