### PR TITLE
Set service_type in [keystone_authtoken] for access rule validation

### DIFF
--- a/templates/neutronapi/config/01-neutron.conf
+++ b/templates/neutronapi/config/01-neutron.conf
@@ -71,6 +71,7 @@ user_domain_name = Default
 project_name = service
 {{- end }}
 interface = internal
+service_type = network
 {{ if (index . "Region") -}}
 region_name = {{ .Region }}
 {{ end -}}

--- a/test/functional/neutronapi_controller_test.go
+++ b/test/functional/neutronapi_controller_test.go
@@ -561,10 +561,11 @@ func getNeutronAPIControllerSuite(ml2MechanismDrivers []string) func() {
 				cfg, err := ini.Load([]byte(configData))
 				Expect(err).ShouldNot(HaveOccurred(), "Should be able to parse config as INI")
 
-				// Verify region_name in [keystone_authtoken]
+				// Verify region_name and service_type in [keystone_authtoken]
 				section := cfg.Section("keystone_authtoken")
 				Expect(section).ShouldNot(BeNil(), "Should find [keystone_authtoken] section")
 				Expect(section.Key("region_name").String()).Should(Equal(testRegion))
+				Expect(section.Key("service_type").String()).Should(Equal("network"))
 
 				// Verify region_name in [nova]
 				section = cfg.Section("nova")


### PR DESCRIPTION
Without service_type configured, keystonemiddleware cannot validate application credentials with custom access rules, causing HTTP 401 for end users.

Closes: [OSPRH-22365](https://redhat.atlassian.net/browse/OSPRH-22365)