### PR TITLE
Remove unnecessary pods RBAC permissions

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -8,6 +8,12 @@ rules:
   - ""
   resources:
   - pods
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
   - secrets
   - services
   verbs:

--- a/internal/controller/neutronapi_controller.go
+++ b/internal/controller/neutronapi_controller.go
@@ -116,7 +116,6 @@ type NeutronAPIReconciler struct {
 // +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=rolebindings,verbs=get;list;watch;create;update;patch
 // service account permissions that are needed to grant permission to the above
 // +kubebuilder:rbac:groups="security.openshift.io",resourceNames=anyuid,resources=securitycontextconstraints,verbs=use
-// +kubebuilder:rbac:groups="",resources=pods,verbs=create;delete;get;list;patch;update;watch;patch
 // +kubebuilder:rbac:groups=topology.openstack.org,resources=topologies,verbs=get;list;watch;update
 
 // Reconcile - neutron api
@@ -940,11 +939,6 @@ func (r *NeutronAPIReconciler) reconcileNormal(ctx context.Context, instance *ne
 			ResourceNames: []string{"anyuid"},
 			Resources:     []string{"securitycontextconstraints"},
 			Verbs:         []string{"use"},
-		},
-		{
-			APIGroups: []string{""},
-			Resources: []string{"pods"},
-			Verbs:     []string{"create", "get", "list", "watch", "update", "patch", "delete"},
 		},
 	}
 	rbacResult, err := common_rbac.ReconcileRbac(ctx, helper, instance, rbacRules)


### PR DESCRIPTION
The workload rbacRules and kubebuilder RBAC markers granted the operator and its workload service account full CRUD (create/delete/get/list/patch/update/ watch) on core Pods, but the operator never reads or writes Pod objects directly — pods only ever come into being indirectly via Deployments/ StatefulSets/Jobs. Remove the unused pods permission and regenerate config/rbac/role.yaml.