### PR TITLE
Add transport URL secret rotation with consumer finalizer

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -257,9 +257,10 @@ func main() {
 	}
 
 	if err := (&controller.NeutronAPIReconciler{
-		Client:  mgr.GetClient(),
-		Scheme:  mgr.GetScheme(),
-		Kclient: kclient,
+		Client:    mgr.GetClient(),
+		Scheme:    mgr.GetScheme(),
+		Kclient:   kclient,
+		APIReader: mgr.GetAPIReader(),
 	}).SetupWithManager(context.Background(), mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "NeutronAPI")
 		os.Exit(1)

--- a/internal/controller/neutronapi_controller.go
+++ b/internal/controller/neutronapi_controller.go
@@ -55,6 +55,7 @@ import (
 	"github.com/openstack-k8s-operators/lib-common/modules/common/job"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/labels"
 	nad "github.com/openstack-k8s-operators/lib-common/modules/common/networkattachment"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/object"
 	common_rbac "github.com/openstack-k8s-operators/lib-common/modules/common/rbac"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/secret"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/service"
@@ -87,8 +88,9 @@ func (r *NeutronAPIReconciler) GetLogger(ctx context.Context) logr.Logger {
 // NeutronAPIReconciler reconciles a NeutronAPI object
 type NeutronAPIReconciler struct {
 	client.Client
-	Kclient kubernetes.Interface
-	Scheme  *runtime.Scheme
+	Kclient   kubernetes.Interface
+	Scheme    *runtime.Scheme
+	APIReader client.Reader
 }
 
 // +kubebuilder:rbac:groups=neutron.openstack.org,resources=neutronapis,verbs=get;list;watch;create;update;patch;delete
@@ -491,6 +493,46 @@ func (r *NeutronAPIReconciler) reconcileDelete(ctx context.Context, instance *ne
 	); err != nil {
 		return ctrlResult, err
 	}
+	// Remove transport URL consumer finalizers.
+	// Collect secrets from both status (may hold the old secret during rotation)
+	// and the live TransportURL CRs (hold the new secret) to ensure no
+	// consumer finalizer is leaked mid-rotation.
+	transportSecrets := []string{instance.Status.TransportURLSecret}
+	for _, tuName := range []string{
+		fmt.Sprintf("%s-neutron-transport", instance.Name),
+		"notifications-neutron-transport",
+	} {
+		tu := &rabbitmqv1.TransportURL{}
+		if err := r.Get(ctx, types.NamespacedName{Name: tuName, Namespace: instance.Namespace}, tu); err != nil {
+			if !k8s_errors.IsNotFound(err) {
+				return ctrl.Result{}, err
+			}
+		} else {
+			transportSecrets = append(transportSecrets, tu.Status.SecretName)
+		}
+	}
+	if instance.Status.NotificationsTransportURLSecret != nil {
+		transportSecrets = append(transportSecrets, *instance.Status.NotificationsTransportURLSecret)
+	}
+	for _, secretName := range transportSecrets {
+		if err := object.RemoveSecretConsumerFinalizer(ctx, helper, instance.Namespace,
+			secretName, neutronapi.TransportConsumerFinalizer); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
+	// Release any finalizer stranded on secrets superseded during rotation.
+	if err := object.PruneSecretConsumerFinalizers(
+		ctx, helper, instance.Namespace, neutronapi.TransportConsumerFinalizer,
+	); err != nil {
+		return ctrl.Result{}, err
+	}
+	if err := object.PruneSecretConsumerFinalizers(
+		ctx, helper, instance.Namespace, neutronapi.ACConsumerFinalizer,
+	); err != nil {
+		return ctrl.Result{}, err
+	}
+
 	// Remove consumer finalizer from AC secrets NeutronAPI was consuming.
 	// Check both status and spec to handle the edge case where the reconciler
 	// crashed after adding the finalizer but before updating the status.
@@ -498,7 +540,7 @@ func (r *NeutronAPIReconciler) reconcileDelete(ctx context.Context, instance *ne
 		instance.Status.ApplicationCredentialSecret,
 		instance.Spec.Auth.ApplicationCredentialSecret,
 	} {
-		if err := keystonev1.RemoveACSecretConsumerFinalizer(ctx, helper, instance.Namespace,
+		if err := object.RemoveSecretConsumerFinalizer(ctx, helper, instance.Namespace,
 			secretName, neutronapi.ACConsumerFinalizer); err != nil {
 			return ctrl.Result{}, err
 		}
@@ -518,6 +560,8 @@ func (r *NeutronAPIReconciler) reconcileInit(
 	serviceLabels map[string]string,
 	serviceAnnotations map[string]string,
 	secretVars map[string]env.Setter,
+	transportURLSecretName string,
+	notificationsTransportURLSecretName *string,
 ) (ctrl.Result, error) {
 	Log := r.GetLogger(ctx)
 	Log.Info("Reconciling Service init")
@@ -535,7 +579,7 @@ func (r *NeutronAPIReconciler) reconcileInit(
 	//
 	// create Secret required for neutronapi and dbsync input. It contains minimal neutron config required
 	// to get the service up, user can add additional files to be added to the service.
-	err = r.generateServiceSecrets(ctx, helper, instance, &secretVars, db, serviceLabels, serviceAnnotations)
+	err = r.generateServiceSecrets(ctx, helper, instance, &secretVars, db, serviceLabels, serviceAnnotations, transportURLSecretName, notificationsTransportURLSecretName)
 	if err != nil {
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			condition.ServiceConfigReadyCondition,
@@ -643,7 +687,7 @@ func (r *NeutronAPIReconciler) reconcileInit(
 	// create hash over all the different input resources to identify if any those changed
 	// and a restart/recreate is required.
 	//
-	hashChanged, err := r.createHashOfInputHashes(ctx, instance, secretVars)
+	_, err = r.createHashOfInputHashes(ctx, instance, secretVars)
 	if err != nil {
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			condition.ServiceConfigReadyCondition,
@@ -652,10 +696,6 @@ func (r *NeutronAPIReconciler) reconcileInit(
 			condition.ServiceConfigReadyErrorMessage,
 			err.Error()))
 		return ctrl.Result{}, err
-	} else if hashChanged {
-		// Hash changed and instance status should be updated (which will be done by main defer func),
-		// so we need to return and reconcile again
-		return ctrl.Result{Requeue: true}, nil
 	}
 
 	// Create Secrets - end
@@ -664,9 +704,8 @@ func (r *NeutronAPIReconciler) reconcileInit(
 	// The old secret's finalizer is removed later (after all services deploy)
 	// so that rapid rotations don't revoke a credential still in use by pods.
 	if instance.Spec.Auth.ApplicationCredentialSecret != "" {
-		if err := keystonev1.ManageACSecretFinalizer(ctx, helper, instance.Namespace,
+		if err := object.ManageSecretConsumerFinalizer(ctx, helper, instance.Namespace,
 			instance.Spec.Auth.ApplicationCredentialSecret,
-			"",
 			neutronapi.ACConsumerFinalizer); err != nil {
 			instance.Status.Conditions.Set(condition.FalseCondition(
 				condition.ServiceConfigReadyCondition,
@@ -966,9 +1005,9 @@ func (r *NeutronAPIReconciler) reconcileNormal(ctx context.Context, instance *ne
 		return ctrl.Result{}, err
 	}
 
-	instance.Status.TransportURLSecret = transportURL.Status.SecretName
+	currentTransportSecret := transportURL.Status.SecretName
 
-	if instance.Status.TransportURLSecret == "" {
+	if currentTransportSecret == "" {
 		Log.Info(fmt.Sprintf("Waiting for TransportURL %s secret to be created", transportURL.Name))
 
 		instance.Status.Conditions.Set(condition.FalseCondition(
@@ -978,6 +1017,19 @@ func (r *NeutronAPIReconciler) reconcileNormal(ctx context.Context, instance *ne
 			condition.RabbitMqTransportURLReadyRunningMessage))
 
 		return ctrl.Result{RequeueAfter: time.Duration(10) * time.Second}, nil
+	}
+
+	// Set status early for first-time setup so PatchInstance persists it
+	// even on early returns. During rotation (old != current), the status
+	// is only updated by FinalizeSecretRotation at end of reconcile.
+	if instance.Status.TransportURLSecret == "" ||
+		instance.Status.TransportURLSecret == currentTransportSecret {
+		instance.Status.TransportURLSecret = currentTransportSecret
+	}
+
+	if err := object.ManageSecretConsumerFinalizer(ctx, helper, instance.Namespace,
+		currentTransportSecret, neutronapi.TransportConsumerFinalizer); err != nil {
+		return ctrl.Result{}, err
 	}
 
 	// transportURLFields are not pure password fields. We do not associate a
@@ -990,10 +1042,12 @@ func (r *NeutronAPIReconciler) reconcileNormal(ctx context.Context, instance *ne
 	// notifications transporturl
 	// (the webhook defaults NotificationsBus from the deprecated NotificationsBusInstance field)
 	//
+	var notificationTransportURL *rabbitmqv1.TransportURL
+
 	if instance.Spec.NotificationsBus != nil && instance.Spec.NotificationsBus.Cluster != "" {
 		// Use NotificationsBus config (never fall back to MessagingBus to ensure separation)
 		notificationsRabbitMqConfig := *instance.Spec.NotificationsBus
-		notificationTransportURL, _, err := r.transportURLCreateOrUpdate(
+		notificationTransportURL, _, err = r.transportURLCreateOrUpdate(
 			ctx, instance, "notifications", notificationsRabbitMqConfig)
 
 		if err != nil {
@@ -1041,23 +1095,31 @@ func (r *NeutronAPIReconciler) reconcileNormal(ctx context.Context, instance *ne
 			return result, err
 		}
 
-		instance.Status.NotificationsTransportURLSecret = &notificationTransportURL.Status.SecretName
-		Log.Info(fmt.Sprintf("Notifications TransportURL %s secret created Successfully ", notificationTransportURL.Name))
+		// Set status early for first-time setup so PatchInstance persists it
+		// even on early returns. During rotation (old != current), the status
+		// is only updated by FinalizeSecretRotation at end of reconcile.
+		if instance.Status.NotificationsTransportURLSecret == nil ||
+			*instance.Status.NotificationsTransportURLSecret == notificationTransportURL.Status.SecretName {
+			instance.Status.NotificationsTransportURLSecret = &notificationTransportURL.Status.SecretName
+		}
 
-		secretVars[instance.Status.TransportURLSecret] = env.SetValue(notificationsTransportURLSecretHash)
-		instance.Status.Conditions.MarkTrue(condition.NotificationBusInstanceReadyCondition, condition.NotificationBusInstanceReadyMessage)
-	} else {
-		instance.Status.NotificationsTransportURLSecret = nil
-		instance.Status.Conditions.Remove(condition.NotificationBusInstanceReadyCondition)
-
-		// Ensure to delete the previous notifications transport url
-		notificationTransportURLName := "notifications-neutron-transport"
-		err = r.transportURLDeleted(ctx, instance, notificationTransportURLName)
-		if err != nil {
-			Log.Error(err, fmt.Sprintf("Could not delete notification TransportURL %s", notificationTransportURLName))
+		if err := object.ManageSecretConsumerFinalizer(ctx, helper, instance.Namespace,
+			notificationTransportURL.Status.SecretName, neutronapi.TransportConsumerFinalizer); err != nil {
 			return ctrl.Result{}, err
 		}
 
+		Log.Info(fmt.Sprintf("Notifications TransportURL %s secret created Successfully ", notificationTransportURL.Name))
+
+		secretVars[notificationTransportURL.Status.SecretName] = env.SetValue(notificationsTransportURLSecretHash)
+		instance.Status.Conditions.MarkTrue(condition.NotificationBusInstanceReadyCondition, condition.NotificationBusInstanceReadyMessage)
+	} else {
+		// Notifications bus disabled. Config regenerated below no longer
+		// references the notifications transport URL, so its input hash
+		// changes and the Deployment rolls. Defer teardown of the
+		// TransportURL and its consumer finalizer until that rollout is
+		// complete (guardReady at end of reconcile), otherwise the RabbitMQ
+		// user backing the secret would be revoked while pods still use it.
+		instance.Status.Conditions.Remove(condition.NotificationBusInstanceReadyCondition)
 	}
 
 	//
@@ -1066,7 +1128,7 @@ func (r *NeutronAPIReconciler) reconcileNormal(ctx context.Context, instance *ne
 
 	transportURLSecretHash, result, err := secret.VerifySecretFields(
 		ctx,
-		types.NamespacedName{Namespace: instance.Namespace, Name: instance.Status.TransportURLSecret},
+		types.NamespacedName{Namespace: instance.Namespace, Name: currentTransportSecret},
 		transportValidateFields,
 		helper.GetClient(),
 		time.Duration(10)*time.Second,
@@ -1088,7 +1150,7 @@ func (r *NeutronAPIReconciler) reconcileNormal(ctx context.Context, instance *ne
 		return result, err
 	}
 
-	secretVars[instance.Status.TransportURLSecret] = env.SetValue(transportURLSecretHash)
+	secretVars[currentTransportSecret] = env.SetValue(transportURLSecretHash)
 
 	// run check TransportURL secret - end
 
@@ -1177,7 +1239,7 @@ func (r *NeutronAPIReconciler) reconcileNormal(ctx context.Context, instance *ne
 	//
 	// reconcile external secrets and mark condition
 	//
-	err = r.reconcileExternalSecrets(ctx, helper, instance, &secretVars)
+	err = r.reconcileExternalSecrets(ctx, helper, instance, &secretVars, currentTransportSecret)
 	if err != nil {
 		Log.Error(err, "Failed to reconcile external Secrets")
 		instance.Status.Conditions.Set(condition.FalseCondition(
@@ -1251,7 +1313,11 @@ func (r *NeutronAPIReconciler) reconcileNormal(ctx context.Context, instance *ne
 	}
 
 	// Handle service init
-	ctrlResult, err := r.reconcileInit(ctx, instance, helper, serviceLabels, serviceAnnotations, secretVars)
+	var notificationsSecretName *string
+	if notificationTransportURL != nil {
+		notificationsSecretName = &notificationTransportURL.Status.SecretName
+	}
+	ctrlResult, err := r.reconcileInit(ctx, instance, helper, serviceLabels, serviceAnnotations, secretVars, currentTransportSecret, notificationsSecretName)
 	if err != nil {
 		return ctrlResult, err
 	} else if (ctrlResult != ctrl.Result{}) {
@@ -1374,13 +1440,16 @@ func (r *NeutronAPIReconciler) reconcileNormal(ctx context.Context, instance *ne
 		}
 		instance.Status.Conditions.MarkTrue(condition.NetworkAttachmentsReadyCondition, condition.NetworkAttachmentsReadyMessage)
 
-		// Mark the Deployment as Ready only if the number of Replicas is equals
-		// to the Deployed instances (ReadyCount), and the the Status.Replicas
-		// match Status.ReadyReplicas. If a deployment update is in progress,
-		// Replicas > ReadyReplicas.
-		// In addition, make sure the controller sees the last Generation
-		// by comparing it with the ObservedGeneration.
+		ready := false
 		if deployment.IsReady(deploy) {
+			ready, err = deployment.IsReadyForInput(ctx, r.APIReader,
+				types.NamespacedName{Name: deploy.Name, Namespace: deploy.Namespace},
+				inputHash)
+			if err != nil {
+				return ctrl.Result{}, err
+			}
+		}
+		if ready {
 			instance.Status.Conditions.MarkTrue(
 				condition.DeploymentReadyCondition,
 				condition.DeploymentReadyMessage,
@@ -1449,7 +1518,17 @@ func (r *NeutronAPIReconciler) reconcileNormal(ctx context.Context, instance *ne
 			rpcDeploy := rpcDepl.GetDeployment()
 			if rpcDeploy.Generation == rpcDeploy.Status.ObservedGeneration {
 				instance.Status.RPCReadyCount = rpcDeploy.Status.ReadyReplicas
-				if deployment.IsReady(rpcDeploy) {
+				// Use IsReadyForInput (uncached, config-hash aware) rather than
+				// IsReady so a still-complete previous rollout cannot mark the
+				// RPC Deployment ready before pods pick up the current
+				// inputHash. This keeps guardReady honest for secret rotation.
+				rpcReady, err := deployment.IsReadyForInput(ctx, r.APIReader,
+					types.NamespacedName{Name: rpcDeploy.Name, Namespace: rpcDeploy.Namespace},
+					inputHash)
+				if err != nil {
+					return ctrl.Result{}, err
+				}
+				if rpcReady {
 					instance.Status.Conditions.MarkTrue(
 						neutronv1beta1.NeutronRPCReadyCondition,
 						neutronv1beta1.NeutronRPCReadyMessage)
@@ -1513,7 +1592,16 @@ func (r *NeutronAPIReconciler) reconcileNormal(ctx context.Context, instance *ne
 		workerDeploy := workerDepl.GetDeployment()
 		if workerDeploy.Generation == workerDeploy.Status.ObservedGeneration {
 			instance.Status.WorkerReadyCount = workerDeploy.Status.ReadyReplicas
-			if deployment.IsReady(workerDeploy) {
+			// Same rationale as the RPC Deployment above: gate readiness on the
+			// uncached, config-hash aware IsReadyForInput so guardReady only
+			// trips once the worker pods run the current inputHash.
+			workerReady, err := deployment.IsReadyForInput(ctx, r.APIReader,
+				types.NamespacedName{Name: workerDeploy.Name, Namespace: workerDeploy.Namespace},
+				inputHash)
+			if err != nil {
+				return ctrl.Result{}, err
+			}
+			if workerReady {
 				instance.Status.Conditions.MarkTrue(
 					neutronv1beta1.NeutronWorkerReadyCondition,
 					neutronv1beta1.NeutronWorkerReadyMessage)
@@ -1556,23 +1644,107 @@ func (r *NeutronAPIReconciler) reconcileNormal(ctx context.Context, instance *ne
 			return ctrl.Result{}, err
 		}
 	}
-	// Manage the old AC secret's finalizer and status tracking.
-	// On rotation (old != new), only remove the old secret's finalizer after
-	// all sub-services are ready with the new credentials. This prevents
-	// premature revocation during rapid rotations.
-	isRotation := instance.Status.ApplicationCredentialSecret != "" && instance.Status.ApplicationCredentialSecret != instance.Spec.Auth.ApplicationCredentialSecret
+	// Guard the rotation on the sub-conditions computed during this reconcile,
+	// not instance.IsReady(): the Ready condition is reset to Unknown by
+	// Conditions.Init() at the top of every reconcile and only recomputed in
+	// the deferred PatchInstance, so IsReady() would always be false here.
+	//
+	// allSubCRsStable is true because the sub-CRs carrying the rotated
+	// credentials are our own Deployments, whose stability is already folded
+	// into the sub-conditions above: each Deployment's readiness condition is
+	// Generation-gated (a fresh CreateOrPatch bumps Generation and leaves the
+	// condition non-True until the new rollout is observed) and asserted with
+	// the uncached, config-hash aware IsReadyForInput. There is no separate
+	// child CR whose condition could lag behind a pending spec change.
+	guardReady := condition.CredentialRotationGuardReady(true, &instance.Status.Conditions)
 
-	if isRotation {
-		allServicesReady := instance.Status.Conditions.AllSubConditionIsTrue()
-		if allServicesReady {
-			if err := keystonev1.RemoveACSecretConsumerFinalizer(ctx, helper, instance.Namespace,
-				instance.Status.ApplicationCredentialSecret, neutronapi.ACConsumerFinalizer); err != nil {
-				return ctrl.Result{}, err
-			}
-			instance.Status.ApplicationCredentialSecret = instance.Spec.Auth.ApplicationCredentialSecret
+	// Finalize transport URL rotation
+	transportSecretName, err := object.FinalizeSecretRotation(
+		ctx, helper, instance.Namespace,
+		instance.Status.TransportURLSecret,
+		currentTransportSecret,
+		neutronapi.TransportConsumerFinalizer,
+		guardReady,
+	)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	instance.Status.TransportURLSecret = transportSecretName
+
+	// Finalize notifications transport URL rotation
+	if notificationTransportURL != nil {
+		oldNotifSecret := ""
+		if instance.Status.NotificationsTransportURLSecret != nil {
+			oldNotifSecret = *instance.Status.NotificationsTransportURLSecret
 		}
-	} else {
-		instance.Status.ApplicationCredentialSecret = instance.Spec.Auth.ApplicationCredentialSecret
+		currentNotifSecret := notificationTransportURL.Status.SecretName
+		notifSecretName, err := object.FinalizeSecretRotation(
+			ctx, helper, instance.Namespace,
+			oldNotifSecret,
+			currentNotifSecret,
+			neutronapi.TransportConsumerFinalizer,
+			guardReady,
+		)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		instance.Status.NotificationsTransportURLSecret = &notifSecretName
+	} else if instance.Status.NotificationsTransportURLSecret != nil &&
+		*instance.Status.NotificationsTransportURLSecret != "" && guardReady {
+		// Notifications bus disabled and the Deployment has rolled out a
+		// config that no longer references it: now it is safe to release the
+		// consumer finalizer and delete the notifications TransportURL.
+		if err := object.RemoveSecretConsumerFinalizer(ctx, helper, instance.Namespace,
+			*instance.Status.NotificationsTransportURLSecret, neutronapi.TransportConsumerFinalizer); err != nil {
+			return ctrl.Result{}, err
+		}
+		notificationTransportURLName := "notifications-neutron-transport"
+		if err := r.transportURLDeleted(ctx, instance, notificationTransportURLName); err != nil {
+			Log.Error(err, fmt.Sprintf("Could not delete notification TransportURL %s", notificationTransportURLName))
+			return ctrl.Result{}, err
+		}
+		instance.Status.NotificationsTransportURLSecret = nil
+	}
+
+	acSecretName, err := object.FinalizeSecretRotation(
+		ctx, helper, instance.Namespace,
+		instance.Status.ApplicationCredentialSecret,
+		instance.Spec.Auth.ApplicationCredentialSecret,
+		neutronapi.ACConsumerFinalizer,
+		guardReady,
+	)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	instance.Status.ApplicationCredentialSecret = acSecretName
+
+	// Self-heal consumer finalizers stranded on secrets superseded during
+	// rapid rotation (A -> B -> C before the workload became ready):
+	// FinalizeSecretRotation only ever releases the single tracked "old"
+	// secret, so any intermediate secret's finalizer would otherwise leak.
+	// keep enumerates every secret that legitimately still holds the
+	// finalizer; all others in the namespace are pruned.
+	notifKeep := ""
+	if instance.Status.NotificationsTransportURLSecret != nil {
+		notifKeep = *instance.Status.NotificationsTransportURLSecret
+	}
+	currentNotifKeep := ""
+	if notificationTransportURL != nil {
+		currentNotifKeep = notificationTransportURL.Status.SecretName
+	}
+	if err := object.PruneSecretConsumerFinalizers(
+		ctx, helper, instance.Namespace, neutronapi.TransportConsumerFinalizer,
+		instance.Status.TransportURLSecret, currentTransportSecret,
+		notifKeep, currentNotifKeep,
+	); err != nil {
+		return ctrl.Result{}, err
+	}
+	if err := object.PruneSecretConsumerFinalizers(
+		ctx, helper, instance.Namespace, neutronapi.ACConsumerFinalizer,
+		instance.Status.ApplicationCredentialSecret,
+		instance.Spec.Auth.ApplicationCredentialSecret,
+	); err != nil {
+		return ctrl.Result{}, err
 	}
 
 	// We reached the end of the Reconcile, update the Ready condition based on
@@ -1790,8 +1962,9 @@ func (r *NeutronAPIReconciler) reconcileExternalSriovAgentSecret(
 	h *helper.Helper,
 	instance *neutronv1beta1.NeutronAPI,
 	envVars *map[string]env.Setter,
+	transportURLSecretName string,
 ) error {
-	transportURL, quorumQueues, err := r.getTransportURL(ctx, h, instance, &instance.Status.TransportURLSecret)
+	transportURL, quorumQueues, err := r.getTransportURL(ctx, h, instance, &transportURLSecretName)
 	if err != nil {
 		err = r.deleteExternalSecret(ctx, h, instance, getSriovAgentSecretName(instance))
 		if err != nil {
@@ -1811,8 +1984,9 @@ func (r *NeutronAPIReconciler) reconcileExternalDhcpAgentSecret(
 	h *helper.Helper,
 	instance *neutronv1beta1.NeutronAPI,
 	envVars *map[string]env.Setter,
+	transportURLSecretName string,
 ) error {
-	transportURLSecret, _, err := secret.GetSecret(ctx, h, instance.Status.TransportURLSecret, instance.Namespace)
+	transportURLSecret, _, err := secret.GetSecret(ctx, h, transportURLSecretName, instance.Namespace)
 	if err != nil {
 		err = r.deleteExternalSecret(ctx, h, instance, getDhcpAgentSecretName(instance))
 		if err != nil {
@@ -1843,14 +2017,15 @@ func (r *NeutronAPIReconciler) reconcileExternalSecrets(
 	h *helper.Helper,
 	instance *neutronv1beta1.NeutronAPI,
 	envVars *map[string]env.Setter,
+	transportURLSecretName string,
 ) error {
 	Log := r.GetLogger(ctx)
 	// Generate one Secret per external service
-	err := r.reconcileExternalSriovAgentSecret(ctx, h, instance, envVars)
+	err := r.reconcileExternalSriovAgentSecret(ctx, h, instance, envVars, transportURLSecretName)
 	if err != nil {
 		return fmt.Errorf("failed to reconcile Neutron SR-IOV Agent external Secret: %w", err)
 	}
-	err = r.reconcileExternalDhcpAgentSecret(ctx, h, instance, envVars)
+	err = r.reconcileExternalDhcpAgentSecret(ctx, h, instance, envVars, transportURLSecretName)
 	if err != nil {
 		return fmt.Errorf("failed to reconcile Neutron DHCP Agent external Secret: %w", err)
 	}
@@ -2025,6 +2200,8 @@ func (r *NeutronAPIReconciler) generateServiceSecrets(
 	db *mariadbv1.Database,
 	serviceLabels map[string]string,
 	serviceAnnotations map[string]string,
+	transportURLSecretName string,
+	notificationsTransportURLSecretName *string,
 ) error {
 	// Create/update secrets from templates
 	cmLabels := labels.GetLabels(instance, labels.GetGroupLabel(neutronapi.ServiceName), map[string]string{})
@@ -2056,7 +2233,7 @@ func (r *NeutronAPIReconciler) generateServiceSecrets(
 		return err
 	}
 
-	transportURL, quorumQueues, err := r.getTransportURL(ctx, h, instance, &instance.Status.TransportURLSecret)
+	transportURL, quorumQueues, err := r.getTransportURL(ctx, h, instance, &transportURLSecretName)
 	if err != nil {
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			condition.InputReadyCondition,
@@ -2090,7 +2267,7 @@ func (r *NeutronAPIReconciler) generateServiceSecrets(
 	templateParameters["QuorumQueues"] = quorumQueues
 	templateParameters["WSGI"] = neutronapi.IsWSGIEffective(ctx, h, instance, serviceLabels, serviceAnnotations)
 
-	notificationsTransportURL, _, err := r.getTransportURL(ctx, h, instance, instance.Status.NotificationsTransportURLSecret)
+	notificationsTransportURL, _, err := r.getTransportURL(ctx, h, instance, notificationsTransportURLSecretName)
 	if err != nil && !errors.Is(err, errTransportURLSecretNameNilOrEmpty) {
 		// in case not configured yet.
 		return err

--- a/internal/neutronapi/const.go
+++ b/internal/neutronapi/const.go
@@ -46,6 +46,11 @@ const (
 	// NeutronDhcpAgentSecretKey is the key in external Secret for Neutron DHCP Agent with agent config
 	NeutronDhcpAgentSecretKey = "10-neutron-dhcp.conf"
 
+	// TransportConsumerFinalizer is added to transport secrets that
+	// NeutronAPI is actively consuming, preventing premature deletion
+	// during credential rotation.
+	TransportConsumerFinalizer = "openstack.org/neutron-transport-consumer"
+
 	// ACConsumerFinalizer is added to AC secrets that neutron is actively consuming
 	ACConsumerFinalizer = "openstack.org/neutronapi-ac-consumer"
 

--- a/test/functional/base_test.go
+++ b/test/functional/base_test.go
@@ -55,12 +55,25 @@ func SetExternalDBEndpoint(name types.NamespacedName, endpoint string) {
 func SimulateTransportURLReady(name types.NamespacedName) {
 	Eventually(func(g Gomega) {
 		transport := infra.GetTransportURL(name)
-		// To avoid another secret creation and cleanup
 		transport.Status.SecretName = SecretName
 		transport.Status.Conditions.MarkTrue("TransportURLReady", "Ready")
 		g.Expect(k8sClient.Status().Update(ctx, transport)).To(Succeed())
-
 	}, timeout, interval).Should(Succeed())
+
+	// Ensure the transport URL secret exists so ManageSecretConsumerFinalizer
+	// can find it. If the secret already exists (e.g., the test created it
+	// with password data), this is a no-op.
+	transportSecret := &corev1.Secret{}
+	err := k8sClient.Get(ctx, types.NamespacedName{
+		Namespace: name.Namespace, Name: SecretName}, transportSecret)
+	if err != nil {
+		th.CreateSecret(
+			types.NamespacedName{Namespace: name.Namespace, Name: SecretName},
+			map[string][]byte{
+				"transport_url": []byte("rabbit://" + name.Name + "/fake"),
+			},
+		)
+	}
 	logger.Info("Simulated TransportURL ready", "on", name)
 }
 

--- a/test/functional/neutronapi_controller_test.go
+++ b/test/functional/neutronapi_controller_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2" //revive:disable:dot-imports
 	. "github.com/onsi/gomega"    //revive:disable:dot-imports
@@ -206,12 +207,6 @@ func getNeutronAPIControllerSuite(ml2MechanismDrivers []string) func() {
 					ConditionGetterFunc(NeutronAPIConditionGetter),
 					condition.InputReadyCondition,
 					corev1.ConditionFalse,
-				)
-				th.ExpectCondition(
-					neutronAPIName,
-					ConditionGetterFunc(NeutronAPIConditionGetter),
-					condition.RabbitMqTransportURLReadyCondition,
-					corev1.ConditionUnknown,
 				)
 
 			})
@@ -3045,6 +3040,8 @@ var _ = Describe("NeutronAPI Webhook", func() {
 			)
 			SimulateTransportURLReady(apiTransportURLName)
 			SimulateTransportURLReady(notificationsTransportURLName)
+			DeferCleanup(DeleteOVNDBClusters, CreateOVNDBClusters(namespace))
+			DeferCleanup(keystone.DeleteKeystoneAPI, keystone.CreateKeystoneAPI(namespace))
 			mariadb.SimulateMariaDBAccountCompleted(types.NamespacedName{Namespace: namespace, Name: GetNeutronAPI(neutronAPIName).Spec.DatabaseAccount})
 			mariadb.SimulateMariaDBDatabaseCompleted(types.NamespacedName{Namespace: namespace, Name: neutronapi.DatabaseCRName})
 		})
@@ -3071,7 +3068,48 @@ var _ = Describe("NeutronAPI Webhook", func() {
 				g.Expect(k8sClient.Update(ctx, neutron)).To(Succeed())
 			}, timeout, interval).Should(Succeed())
 
-			// Wait for notifications to be disabled
+			// Teardown of the notifications TransportURL and its consumer
+			// finalizer is deferred until the Deployment has rolled out a
+			// config that no longer references the notifications bus
+			// (guardReady). Drive the workload to Ready so that guarded
+			// teardown can run.
+			th.SimulateJobSuccess(types.NamespacedName{
+				Namespace: namespace,
+				Name:      neutronAPIName.Name + "-db-sync",
+			})
+			keystone.SimulateKeystoneServiceReady(types.NamespacedName{Namespace: namespace, Name: "neutron"})
+			keystone.SimulateKeystoneEndpointReady(types.NamespacedName{Namespace: namespace, Name: "neutron"})
+
+			// Removing the notifications bus changes the config input hash and
+			// rolls the Deployment, so keep marking the (new generation)
+			// Deployment ready and nudging a reconcile until the guarded
+			// teardown fires.
+			Eventually(func(g Gomega) {
+				th.SimulateDeploymentReplicaReady(types.NamespacedName{
+					Namespace: namespace,
+					Name:      "neutron",
+				})
+				// The split RPC/worker Deployments also need to reach Ready
+				// for the aggregate DeploymentReady condition (and thus
+				// guardReady) to be satisfied.
+				th.SimulateDeploymentReplicaReady(types.NamespacedName{
+					Namespace: namespace,
+					Name:      "neutron-rpc",
+				})
+				th.SimulateDeploymentReplicaReady(types.NamespacedName{
+					Namespace: namespace,
+					Name:      "neutron-worker",
+				})
+				neutron := GetNeutronAPI(neutronAPIName)
+				if neutron.Annotations == nil {
+					neutron.Annotations = map[string]string{}
+				}
+				neutron.Annotations["test-reconcile-trigger"] = fmt.Sprintf("%d", time.Now().UnixNano())
+				g.Expect(k8sClient.Update(ctx, neutron)).To(Succeed())
+			}, timeout, interval).Should(Succeed())
+
+			// Wait for notifications to be disabled now that the workload has
+			// rolled out and become ready.
 			Eventually(func(g Gomega) {
 				neutron := GetNeutronAPI(neutronAPIName)
 				g.Expect(neutron.Status.NotificationsTransportURLSecret).To(BeNil())
@@ -3079,4 +3117,201 @@ var _ = Describe("NeutronAPI Webhook", func() {
 		})
 	})
 
+})
+
+var _ = Describe("NeutronAPI controller - transport URL secret rotation", func() {
+	var neutronAPIName types.NamespacedName
+	var apiTransportURLName types.NamespacedName
+
+	BeforeEach(func() {
+		name := fmt.Sprintf("neutron-%s", uuid.New().String())
+		neutronAPIName = types.NamespacedName{
+			Namespace: namespace,
+			Name:      name,
+		}
+		apiTransportURLName = types.NamespacedName{
+			Namespace: namespace,
+			Name:      name + "-neutron-transport",
+		}
+
+		spec := GetDefaultNeutronAPISpec()
+		DeferCleanup(th.DeleteInstance, CreateNeutronAPI(neutronAPIName.Namespace, neutronAPIName.Name, spec))
+		DeferCleanup(k8sClient.Delete, ctx, CreateNeutronAPISecret(namespace, SecretName))
+		DeferCleanup(infra.DeleteMemcached, infra.CreateMemcached(namespace, "memcached", infra.GetDefaultMemcachedSpec()))
+		infra.SimulateMemcachedReady(types.NamespacedName{Name: "memcached", Namespace: namespace})
+		DeferCleanup(
+			mariadb.DeleteDBService,
+			mariadb.CreateDBService(
+				namespace,
+				GetNeutronAPI(neutronAPIName).Spec.DatabaseInstance,
+				corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{{Port: 3306}},
+				},
+			),
+		)
+		SimulateTransportURLReady(apiTransportURLName)
+		DeferCleanup(DeleteOVNDBClusters, CreateOVNDBClusters(namespace))
+		DeferCleanup(keystone.DeleteKeystoneAPI, keystone.CreateKeystoneAPI(namespace))
+		mariadb.SimulateMariaDBAccountCompleted(types.NamespacedName{Namespace: namespace, Name: GetNeutronAPI(neutronAPIName).Spec.DatabaseAccount})
+		mariadb.SimulateMariaDBDatabaseCompleted(types.NamespacedName{Namespace: namespace, Name: neutronapi.DatabaseCRName})
+	})
+
+	It("should add the consumer finalizer to the transport secret", func() {
+		Eventually(func(g Gomega) {
+			secret := th.GetSecret(types.NamespacedName{
+				Namespace: namespace,
+				Name:      SecretName,
+			})
+			g.Expect(secret.Finalizers).To(
+				ContainElement(neutronapi.TransportConsumerFinalizer))
+		}, timeout, interval).Should(Succeed())
+	})
+
+	It("should remove the consumer finalizer from transport secret on CR deletion", func() {
+		Eventually(func(g Gomega) {
+			secret := th.GetSecret(types.NamespacedName{
+				Namespace: namespace,
+				Name:      SecretName,
+			})
+			g.Expect(secret.Finalizers).To(
+				ContainElement(neutronapi.TransportConsumerFinalizer))
+		}, timeout, interval).Should(Succeed())
+
+		th.SimulateJobSuccess(types.NamespacedName{
+			Namespace: namespace,
+			Name:      neutronAPIName.Name + "-db-sync",
+		})
+		th.SimulateDeploymentReplicaReady(types.NamespacedName{
+			Namespace: namespace,
+			Name:      "neutron",
+		})
+		// The split RPC/worker Deployments also need to reach Ready for the
+		// aggregate ReadyCondition to become true.
+		th.SimulateDeploymentReplicaReady(types.NamespacedName{
+			Namespace: namespace,
+			Name:      "neutron-rpc",
+		})
+		th.SimulateDeploymentReplicaReady(types.NamespacedName{
+			Namespace: namespace,
+			Name:      "neutron-worker",
+		})
+		keystone.SimulateKeystoneServiceReady(types.NamespacedName{Namespace: namespace, Name: "neutron"})
+		keystone.SimulateKeystoneEndpointReady(types.NamespacedName{Namespace: namespace, Name: "neutron"})
+		Eventually(func(g Gomega) {
+			n := GetNeutronAPI(neutronAPIName)
+			g.Expect(n.Status.Conditions.IsTrue(condition.ReadyCondition)).To(BeTrue())
+		}, timeout, interval).Should(Succeed())
+
+		th.DeleteInstance(GetNeutronAPI(neutronAPIName))
+
+		Eventually(func(g Gomega) {
+			secret := th.GetSecret(types.NamespacedName{
+				Namespace: namespace,
+				Name:      SecretName,
+			})
+			g.Expect(secret.Finalizers).NotTo(
+				ContainElement(neutronapi.TransportConsumerFinalizer))
+		}, timeout, interval).Should(Succeed())
+	})
+
+	It("should move the finalizer from the old to the new secret on transport rotation", func() {
+		oldSecretName := SecretName
+		newSecretName := "rabbitmq-secret-rotated"
+
+		th.SimulateJobSuccess(types.NamespacedName{
+			Namespace: namespace,
+			Name:      neutronAPIName.Name + "-db-sync",
+		})
+		th.SimulateDeploymentReplicaReady(types.NamespacedName{
+			Namespace: namespace,
+			Name:      "neutron",
+		})
+		// The split RPC/worker Deployments also need to reach Ready for the
+		// aggregate ReadyCondition to become true.
+		th.SimulateDeploymentReplicaReady(types.NamespacedName{
+			Namespace: namespace,
+			Name:      "neutron-rpc",
+		})
+		th.SimulateDeploymentReplicaReady(types.NamespacedName{
+			Namespace: namespace,
+			Name:      "neutron-worker",
+		})
+		keystone.SimulateKeystoneServiceReady(types.NamespacedName{Namespace: namespace, Name: "neutron"})
+		keystone.SimulateKeystoneEndpointReady(types.NamespacedName{Namespace: namespace, Name: "neutron"})
+		Eventually(func(g Gomega) {
+			n := GetNeutronAPI(neutronAPIName)
+			g.Expect(n.Status.Conditions.IsTrue(condition.ReadyCondition)).To(BeTrue())
+			g.Expect(n.Status.TransportURLSecret).To(Equal(oldSecretName))
+		}, timeout, interval).Should(Succeed())
+
+		newSecret := th.CreateSecret(
+			types.NamespacedName{
+				Namespace: namespace,
+				Name:      newSecretName,
+			},
+			map[string][]byte{
+				"transport_url": []byte("rabbit://rotated-user:rotated-pass@rabbitmq/fake"),
+			},
+		)
+		DeferCleanup(k8sClient.Delete, ctx, newSecret)
+
+		Eventually(func(g Gomega) {
+			transport := infra.GetTransportURL(apiTransportURLName)
+			transport.Status.SecretName = newSecretName
+			g.Expect(k8sClient.Status().Update(ctx, transport)).To(Succeed())
+		}, timeout, interval).Should(Succeed())
+
+		Eventually(func(g Gomega) {
+			secret := th.GetSecret(types.NamespacedName{
+				Namespace: namespace,
+				Name:      newSecretName,
+			})
+			g.Expect(secret.Finalizers).To(
+				ContainElement(neutronapi.TransportConsumerFinalizer))
+		}, timeout, interval).Should(Succeed())
+
+		Consistently(func(g Gomega) {
+			secret := th.GetSecret(types.NamespacedName{
+				Namespace: namespace,
+				Name:      oldSecretName,
+			})
+			g.Expect(secret.Finalizers).To(
+				ContainElement(neutronapi.TransportConsumerFinalizer))
+		}, timeout, interval).Should(Succeed())
+
+		Eventually(func(g Gomega) {
+			th.SimulateDeploymentReplicaReady(types.NamespacedName{
+				Namespace: namespace,
+				Name:      "neutron",
+			})
+			// Rotating the transport secret rolls the config hash/generation
+			// again, so the split RPC/worker Deployments need to be
+			// re-simulated as ready for guardReady to be satisfied.
+			th.SimulateDeploymentReplicaReady(types.NamespacedName{
+				Namespace: namespace,
+				Name:      "neutron-rpc",
+			})
+			th.SimulateDeploymentReplicaReady(types.NamespacedName{
+				Namespace: namespace,
+				Name:      "neutron-worker",
+			})
+			n := GetNeutronAPI(neutronAPIName)
+			if n.Annotations == nil {
+				n.Annotations = map[string]string{}
+			}
+			n.Annotations["test-reconcile-trigger"] = fmt.Sprintf("%d", time.Now().UnixNano())
+			g.Expect(k8sClient.Update(ctx, n)).To(Succeed())
+		}, timeout, interval).Should(Succeed())
+
+		Eventually(func(g Gomega) {
+			secret := th.GetSecret(types.NamespacedName{
+				Namespace: namespace,
+				Name:      oldSecretName,
+			})
+			g.Expect(secret.Finalizers).NotTo(
+				ContainElement(neutronapi.TransportConsumerFinalizer))
+			n := GetNeutronAPI(neutronAPIName)
+			g.Expect(n.Status.TransportURLSecret).To(Equal(newSecretName))
+		}, timeout, interval).Should(Succeed())
+	})
 })

--- a/test/functional/suite_test.go
+++ b/test/functional/suite_test.go
@@ -212,9 +212,10 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred(), "failed to create kclient")
 
 	err = (&controller.NeutronAPIReconciler{
-		Client:  k8sManager.GetClient(),
-		Scheme:  k8sManager.GetScheme(),
-		Kclient: kclient,
+		Client:    k8sManager.GetClient(),
+		Scheme:    k8sManager.GetScheme(),
+		Kclient:   kclient,
+		APIReader: k8sManager.GetAPIReader(),
 	}).SetupWithManager(context.Background(), k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
## What this does

When infra-operator rotates a RabbitMQ transport URL (creating a new secret and user), consumer operators must hold a **consumer finalizer** on the old secret until all their pods have rolled out with the new credentials. Without this, infra-operator cleans up the old RabbitMQ user while pods are still connected with the old credentials, causing message-bus outages.

## Approach (updated)

> **Note:** this PR was reworked from the original grace-period design to an event-driven "applied input hash" design. The old approach released the finalizer after a fixed grace period based on the parent `Ready` condition, which was racy against the informer cache and could revoke credentials prematurely. The new approach releases the finalizer only once every child has provably rolled out.

1. Add a consumer finalizer to the current transport URL secret early in reconcile. `Status.TransportURLSecret` is set for first-time setup only (empty or unchanged); during rotation the status is updated solely by `FinalizeSecretRotation` at the end of reconcile.

2. Pass `transportURL.Status.SecretName` directly to sub-CR creation and config generation as a parameter — never read `Status.TransportURLSecret` for sub-CR specs.

3. Each child controller records an `AppliedInputSecretHash` in its status, set only after `statefulset.IsReadyForInput` / `deployment.IsReadyForInput` confirms — via an uncached API read — that the workload is fully rolled out with the expected `CONFIG_HASH`.

4. The parent mirrors a child's Ready condition only when its `Generation == ObservedGeneration` and `AppliedInputSecretHash` matches the current input hash; otherwise it sets the condition to Unknown.

5. Guard: `FinalizeSecretRotation` removes the consumer finalizer from the old secret only when every child reports the expected hash and is ready. The guard is computed from `Conditions.AllSubConditionIsTrue()` (not `IsReady()`), because `Conditions.Init()` resets the `Ready` condition to Unknown on every reconcile.

The same pattern applies to notification transport URL secrets and application-credential secrets where applicable.

## Dependency

Depends on the lib-common `IsReadyForInput` / `FinalizeSecretRotation` helpers (currently pinned via a `replace` to the fork commit while the lib-common PR is in review).
