### PR TITLE
Add CRD change check workflow for maintenance branches

### DIFF
--- a/.github/workflows/crd-change-check.yaml
+++ b/.github/workflows/crd-change-check.yaml
@@ -1,0 +1,11 @@
+name: CRD change check
+
+on:
+  pull_request:
+    branches:
+      - '18.0-fr[0-9]*'
+      - '19.[0-9]*'
+
+jobs:
+  crd-change-check:
+    uses: openstack-k8s-operators/openstack-k8s-operators-ci/.github/workflows/reusable-crd-change-check.yaml@main


### PR DESCRIPTION
Calls the shared reusable-crd-change-check workflow on PRs targeting 18.0-frX and 19.X maintenance branches to prevent unintended CRD changes.

Jira: [OSPRH-32473](https://redhat.atlassian.net/browse/OSPRH-32473)