### PR TITLE
Add and default to WSGI strategy and master container images

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ kind: NeutronAPI
 metadata:
   name: neutron
 spec:
-  containerImage: quay.io/tripleowallabycentos9/openstack-neutron-server:current-podified
   databaseInstance: openstack
   secret: neutron-secret
 ```
@@ -206,7 +205,6 @@ spec:
   rabbitMqClusterName: rabbitmq
   memcachedInstance: memcached
   preserveJobs: false
-  containerImage: quay.io/podified-antelope-centos9/openstack-neutron-server:current-podified
   replicas: 1
   secret: neutron-secret
   extraMounts:

--- a/api/bases/neutron.openstack.org_neutronapis.yaml
+++ b/api/bases/neutron.openstack.org_neutronapis.yaml
@@ -1306,9 +1306,22 @@ spec:
                 description: ReadyCount of neutron API instances
                 format: int32
                 type: integer
+              rpcReadyCount:
+                description: |-
+                  RPCReadyCount of neutron-rpc-server instances. Only populated when the
+                  WSGI deployment strategy is enabled and the RPC worker is not disabled
+                  via rpc_workers=0 in customServiceConfig.
+                format: int32
+                type: integer
               transportURLSecret:
                 description: TransportURLSecret - Secret containing RabbitMQ transportURL
                 type: string
+              workerReadyCount:
+                description: |-
+                  WorkerReadyCount of neutron background worker (periodic/OVN maintenance)
+                  instances. Only populated when the WSGI deployment strategy is enabled.
+                format: int32
+                type: integer
             type: object
         type: object
     served: true

--- a/api/v1beta1/conditions.go
+++ b/api/v1beta1/conditions.go
@@ -24,6 +24,15 @@ import (
 const (
 	// Neutron External Configs Ready indicates when the external config is ready
 	NeutronExternalConfigsReady condition.Type = "Neutron External Configs Ready"
+
+	// NeutronRPCReadyCondition indicates the status of the neutron-rpc
+	// Deployment (neutron-rpc-server), only used under the WSGI strategy
+	NeutronRPCReadyCondition condition.Type = "NeutronRPCReady"
+
+	// NeutronWorkerReadyCondition indicates the status of the neutron-worker
+	// Deployment (periodic/OVN maintenance workers), only used under the
+	// WSGI strategy
+	NeutronWorkerReadyCondition condition.Type = "NeutronWorkerReady"
 )
 
 // Common Messages used by API objects.
@@ -34,4 +43,24 @@ const (
 
 	//NeutronDhcpAgentConfigErrorMessageW
 	NeutronExternalConfigsErrorMessage = "Neutron external configs generation error occurred %s"
+
+	// NeutronRPCReadyInitMessage
+	NeutronRPCReadyInitMessage = "NeutronRPC not started"
+	// NeutronRPCReadyMessage
+	NeutronRPCReadyMessage = "NeutronRPC ready"
+	// NeutronRPCDisabledMessage
+	NeutronRPCDisabledMessage = "NeutronRPC disabled by rpc_workers=0 in customServiceConfig"
+	// NeutronRPCReadyRunningMessage
+	NeutronRPCReadyRunningMessage = "NeutronRPC deployment in progress"
+	// NeutronRPCReadyErrorMessage
+	NeutronRPCReadyErrorMessage = "NeutronRPC error occurred %s"
+
+	// NeutronWorkerReadyInitMessage
+	NeutronWorkerReadyInitMessage = "NeutronWorker not started"
+	// NeutronWorkerReadyMessage
+	NeutronWorkerReadyMessage = "NeutronWorker ready"
+	// NeutronWorkerReadyRunningMessage
+	NeutronWorkerReadyRunningMessage = "NeutronWorker deployment in progress"
+	// NeutronWorkerReadyErrorMessage
+	NeutronWorkerReadyErrorMessage = "NeutronWorker error occurred %s"
 )

--- a/api/v1beta1/neutronapi_types.go
+++ b/api/v1beta1/neutronapi_types.go
@@ -17,6 +17,9 @@ limitations under the License.
 package v1beta1
 
 import (
+	"strconv"
+	"strings"
+
 	rabbitmqv1 "github.com/openstack-k8s-operators/infra-operator/apis/rabbitmq/v1beta1"
 	topologyv1 "github.com/openstack-k8s-operators/infra-operator/apis/topology/v1beta1"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
@@ -38,8 +41,24 @@ const (
 
 	// Container image fall-back defaults
 
-	// NeutronAPIContainerImage is the fall-back container image for NeutronAPI
-	NeutronAPIContainerImage = "quay.io/podified-antelope-centos9/openstack-neutron-server:current-podified"
+	// NeutronAPIContainerImage is the fall-back container image for NeutronAPI.
+	// This is a master-branch image (Eventlet removed, WSGI/neutron-rpc-server
+	// support present) -- it must stay in lockstep with the IsWSGI() default
+	// below: an Eventlet default would not run on this image, and a WSGI
+	// default would not run on an Antelope-era image.
+	NeutronAPIContainerImage = "quay.io/openstack-s2i-containers/openstack-neutron-server:master-latest"
+
+	// NeutronWSGILabel is the annotation used to select between the WSGI
+	// (httpd/mod_wsgi + separate neutron-rpc-server/worker Deployments) and
+	// the legacy Eventlet (neutron-server + httpd reverse-proxy) deployment
+	// strategies. It is set by openstack-operator on every reconcile, based
+	// on OpenStackVersion.Status.ServiceDefaults.NeutronWsgi, so that
+	// upgrading openstack-operator alone never changes the strategy of an
+	// existing deployment: that value stays pinned to whatever was computed
+	// for the deployment's targeted version until the control plane is
+	// explicitly moved to one where it is true. See IsWSGI() for the
+	// (unrelated) default used when the annotation is absent entirely.
+	NeutronWSGILabel = "neutron.openstack.org/wsgi"
 )
 
 // NeutronAPISpec defines the desired state of NeutronAPI
@@ -256,6 +275,15 @@ type NeutronAPIStatus struct {
 	// NotificationsTransportURLSecret - Secret containing
 	// external notifications transportURL
 	NotificationsTransportURLSecret *string `json:"notificationsTransportURLSecret,omitempty"`
+
+	// RPCReadyCount of neutron-rpc-server instances. Only populated when the
+	// WSGI deployment strategy is enabled and the RPC worker is not disabled
+	// via rpc_workers=0 in customServiceConfig.
+	RPCReadyCount int32 `json:"rpcReadyCount,omitempty"`
+
+	// WorkerReadyCount of neutron background worker (periodic/OVN maintenance)
+	// instances. Only populated when the WSGI deployment strategy is enabled.
+	WorkerReadyCount int32 `json:"workerReadyCount,omitempty"`
 }
 
 // +kubebuilder:object:root=true
@@ -332,6 +360,26 @@ func (instance NeutronAPI) RbacResourceName() string {
 	return "neutron-" + instance.Name
 }
 
+// IsWSGI - returns true if this NeutronAPI should be deployed using the
+// WSGI strategy (httpd/mod_wsgi + separate neutron-rpc/neutron-worker
+// Deployments), based on the NeutronWSGILabel annotation. Absent the
+// annotation, it defaults to true, matching NeutronAPIContainerImage
+// (a master-branch image that no longer supports Eventlet)
+//
+// This default only governs standalone use of neutron-operator (no
+// annotation ever set). Real backward compatibility for openstack-operator
+// managed deployments is NOT provided here: it comes entirely from
+// openstack-operator explicitly setting this annotation on every reconcile,
+// based on OpenStackVersion.Status.ServiceDefaults.NeutronWsgi, which stays
+// pinned to whatever value was computed for a deployment's targeted
+// version until the control plane is moved to a version where it is true.
+func (instance NeutronAPI) IsWSGI() bool {
+	if v, ok := instance.GetAnnotations()[NeutronWSGILabel]; ok {
+		return v == "true"
+	}
+	return true
+}
+
 func (instance NeutronAPI) IsOVNEnabled() bool {
 	for _, driver := range instance.Spec.Ml2MechanismDrivers {
 		// TODO: use const
@@ -340,6 +388,43 @@ func (instance NeutronAPI) IsOVNEnabled() bool {
 		}
 	}
 	return false
+}
+
+// GetRPCWorkers parses instance.Spec.CustomServiceConfig for an explicit
+// rpc_workers setting under the [DEFAULT] section (the only section
+// rpc_workers is valid in), the same way GetEnabledBackends() does for
+// Glance's enabled_backends. Returns -1 if rpc_workers isn't set (or isn't
+// parseable), which can never be a real worker count, so callers can compare
+// directly against 0 without a separate "was it set" flag. Used to decide
+// whether the neutron-rpc Deployment should be disabled (rpc_workers=0) when
+// running under the WSGI strategy.
+func GetRPCWorkers(customServiceConfig string) int {
+	// Content before any section header belongs to the implicit [DEFAULT]
+	// section, matching Python's configparser (and oslo.config) semantics.
+	section := "DEFAULT"
+	for _, line := range strings.Split(customServiceConfig, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			// Skip blank lines and comments
+			continue
+		}
+		if strings.HasPrefix(trimmed, "[") && strings.HasSuffix(trimmed, "]") {
+			section = strings.TrimSpace(trimmed[1 : len(trimmed)-1])
+			continue
+		}
+		if section != "DEFAULT" {
+			continue
+		}
+		tokenLine := strings.SplitN(trimmed, "=", 2)
+		token := strings.ReplaceAll(tokenLine[0], " ", "")
+		if token == "rpc_workers" && len(tokenLine) == 2 {
+			val, err := strconv.Atoi(strings.TrimSpace(tokenLine[1]))
+			if err == nil {
+				return val
+			}
+		}
+	}
+	return -1
 }
 
 // SetupDefaults - initializes any CRD field defaults based on environment variables (the defaulting mechanism itself is implemented via webhooks)

--- a/config/crd/bases/neutron.openstack.org_neutronapis.yaml
+++ b/config/crd/bases/neutron.openstack.org_neutronapis.yaml
@@ -1306,9 +1306,22 @@ spec:
                 description: ReadyCount of neutron API instances
                 format: int32
                 type: integer
+              rpcReadyCount:
+                description: |-
+                  RPCReadyCount of neutron-rpc-server instances. Only populated when the
+                  WSGI deployment strategy is enabled and the RPC worker is not disabled
+                  via rpc_workers=0 in customServiceConfig.
+                format: int32
+                type: integer
               transportURLSecret:
                 description: TransportURLSecret - Secret containing RabbitMQ transportURL
                 type: string
+              workerReadyCount:
+                description: |-
+                  WorkerReadyCount of neutron background worker (periodic/OVN maintenance)
+                  instances. Only populated when the WSGI deployment strategy is enabled.
+                format: int32
+                type: integer
             type: object
         type: object
     served: true

--- a/config/default/manager_default_images.yaml
+++ b/config/default/manager_default_images.yaml
@@ -12,4 +12,4 @@ spec:
       - name: manager
         env:
         - name: RELATED_IMAGE_NEUTRON_API_IMAGE_URL_DEFAULT
-          value: quay.io/podified-antelope-centos9/openstack-neutron-server:current-podified
+          value: quay.io/openstack-s2i-containers/openstack-neutron-server:master-latest

--- a/internal/controller/neutronapi_controller.go
+++ b/internal/controller/neutronapi_controller.go
@@ -1314,7 +1314,9 @@ func (r *NeutronAPIReconciler) reconcileNormal(ctx context.Context, instance *ne
 		instance.Status.LastAppliedTopology = nil
 	}
 
-	deplDef, err := neutronapi.Deployment(instance, inputHash, serviceLabels, serviceAnnotations, topology, memcached)
+	wsgi := instance.IsWSGI()
+
+	deplDef, err := neutronapi.Deployment(instance, inputHash, serviceLabels, serviceAnnotations, topology, memcached, wsgi)
 	if err != nil {
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			condition.DeploymentReadyCondition,
@@ -1392,6 +1394,159 @@ func (r *NeutronAPIReconciler) reconcileNormal(ctx context.Context, instance *ne
 		}
 	}
 	// create Deployment - end
+
+	//
+	// neutron-rpc / neutron-worker Deployments (WSGI strategy only)
+	//
+	if wsgi {
+		// rpc_workers=0 in customServiceConfig means the human operator has
+		// explicitly asked for no RPC workers -- skip (and clean up) the
+		// neutron-rpc Deployment entirely rather than scaling it to 0, since
+		// there is no HTTP endpoint behind it to keep alive at 0 replicas.
+		rpcEnabled := neutronv1beta1.GetRPCWorkers(instance.Spec.CustomServiceConfig) != 0
+		rpcName := fmt.Sprintf("%s-%s", neutronapi.ServiceName, neutronapi.RPCDeploymentSuffix)
+
+		if rpcEnabled {
+			// Seed a non-true state before CreateOrPatch: it returns an
+			// empty ctrl.Result even right after creating a brand-new
+			// Deployment, and immediately post-create Generation !=
+			// ObservedGeneration, so the Generation-gated block below can
+			// be skipped entirely on this pass. Without this seed, the
+			// condition would stay absent rather than False -- and
+			// AllSubConditionIsTrue() ignores absent conditions, which
+			// could let the aggregate Ready condition go True before the
+			// RPC Deployment has actually rolled out any pods.
+			instance.Status.Conditions.Set(condition.FalseCondition(
+				neutronv1beta1.NeutronRPCReadyCondition,
+				condition.RequestedReason,
+				condition.SeverityInfo,
+				neutronv1beta1.NeutronRPCReadyRunningMessage))
+
+			rpcLabels := map[string]string{
+				common.AppSelector: rpcName,
+			}
+			rpcDeplDef := neutronapi.RPCDeployment(instance, inputHash, rpcLabels, serviceAnnotations, topology, memcached)
+			rpcDepl := deployment.NewDeployment(rpcDeplDef, time.Duration(5)*time.Second)
+
+			ctrlResult, err = rpcDepl.CreateOrPatch(ctx, helper)
+			if err != nil {
+				instance.Status.Conditions.Set(condition.FalseCondition(
+					neutronv1beta1.NeutronRPCReadyCondition,
+					condition.ErrorReason,
+					condition.SeverityWarning,
+					neutronv1beta1.NeutronRPCReadyErrorMessage,
+					err.Error()))
+				return ctrlResult, err
+			} else if (ctrlResult != ctrl.Result{}) {
+				instance.Status.Conditions.Set(condition.FalseCondition(
+					neutronv1beta1.NeutronRPCReadyCondition,
+					condition.RequestedReason,
+					condition.SeverityInfo,
+					neutronv1beta1.NeutronRPCReadyRunningMessage))
+				return ctrlResult, nil
+			}
+
+			rpcDeploy := rpcDepl.GetDeployment()
+			if rpcDeploy.Generation == rpcDeploy.Status.ObservedGeneration {
+				instance.Status.RPCReadyCount = rpcDeploy.Status.ReadyReplicas
+				if deployment.IsReady(rpcDeploy) {
+					instance.Status.Conditions.MarkTrue(
+						neutronv1beta1.NeutronRPCReadyCondition,
+						neutronv1beta1.NeutronRPCReadyMessage)
+				} else {
+					instance.Status.Conditions.Set(condition.FalseCondition(
+						neutronv1beta1.NeutronRPCReadyCondition,
+						condition.RequestedReason,
+						condition.SeverityInfo,
+						neutronv1beta1.NeutronRPCReadyRunningMessage))
+				}
+			}
+		} else {
+			// rpc_workers=0: remove a previously-created neutron-rpc
+			// Deployment, e.g. left over from before the user disabled it.
+			existingRPC := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Name: rpcName, Namespace: instance.Namespace},
+			}
+			if err := helper.GetClient().Delete(ctx, existingRPC); err != nil && !k8s_errors.IsNotFound(err) {
+				return ctrl.Result{}, err
+			}
+			instance.Status.RPCReadyCount = 0
+			instance.Status.Conditions.MarkTrue(
+				neutronv1beta1.NeutronRPCReadyCondition,
+				neutronv1beta1.NeutronRPCDisabledMessage)
+		}
+
+		// Same seeding rationale as NeutronRPCReadyCondition above: the
+		// worker Deployment is always active under wsgi, so its condition
+		// must never be left absent while CreateOrPatch/Generation catch up.
+		instance.Status.Conditions.Set(condition.FalseCondition(
+			neutronv1beta1.NeutronWorkerReadyCondition,
+			condition.RequestedReason,
+			condition.SeverityInfo,
+			neutronv1beta1.NeutronWorkerReadyRunningMessage))
+
+		workerName := fmt.Sprintf("%s-%s", neutronapi.ServiceName, neutronapi.WorkerDeploymentSuffix)
+		workerLabels := map[string]string{
+			common.AppSelector: workerName,
+		}
+		workerDeplDef := neutronapi.WorkerDeployment(instance, inputHash, workerLabels, serviceAnnotations, topology, memcached)
+		workerDepl := deployment.NewDeployment(workerDeplDef, time.Duration(5)*time.Second)
+
+		ctrlResult, err = workerDepl.CreateOrPatch(ctx, helper)
+		if err != nil {
+			instance.Status.Conditions.Set(condition.FalseCondition(
+				neutronv1beta1.NeutronWorkerReadyCondition,
+				condition.ErrorReason,
+				condition.SeverityWarning,
+				neutronv1beta1.NeutronWorkerReadyErrorMessage,
+				err.Error()))
+			return ctrlResult, err
+		} else if (ctrlResult != ctrl.Result{}) {
+			instance.Status.Conditions.Set(condition.FalseCondition(
+				neutronv1beta1.NeutronWorkerReadyCondition,
+				condition.RequestedReason,
+				condition.SeverityInfo,
+				neutronv1beta1.NeutronWorkerReadyRunningMessage))
+			return ctrlResult, nil
+		}
+
+		workerDeploy := workerDepl.GetDeployment()
+		if workerDeploy.Generation == workerDeploy.Status.ObservedGeneration {
+			instance.Status.WorkerReadyCount = workerDeploy.Status.ReadyReplicas
+			if deployment.IsReady(workerDeploy) {
+				instance.Status.Conditions.MarkTrue(
+					neutronv1beta1.NeutronWorkerReadyCondition,
+					neutronv1beta1.NeutronWorkerReadyMessage)
+			} else {
+				instance.Status.Conditions.Set(condition.FalseCondition(
+					neutronv1beta1.NeutronWorkerReadyCondition,
+					condition.RequestedReason,
+					condition.SeverityInfo,
+					neutronv1beta1.NeutronWorkerReadyRunningMessage))
+			}
+		}
+	} else {
+		// Legacy Eventlet strategy: clean up any neutron-rpc/neutron-worker
+		// Deployments left over from a previous wsgi=true reconcile (e.g. the
+		// openstack-operator flipped the annotation back), and drop their
+		// conditions so they don't affect the aggregate Ready condition.
+		for _, name := range []string{
+			fmt.Sprintf("%s-%s", neutronapi.ServiceName, neutronapi.RPCDeploymentSuffix),
+			fmt.Sprintf("%s-%s", neutronapi.ServiceName, neutronapi.WorkerDeploymentSuffix),
+		} {
+			existing := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: instance.Namespace},
+			}
+			if err := helper.GetClient().Delete(ctx, existing); err != nil && !k8s_errors.IsNotFound(err) {
+				return ctrl.Result{}, err
+			}
+		}
+		instance.Status.RPCReadyCount = 0
+		instance.Status.WorkerReadyCount = 0
+		instance.Status.Conditions.Remove(neutronv1beta1.NeutronRPCReadyCondition)
+		instance.Status.Conditions.Remove(neutronv1beta1.NeutronWorkerReadyCondition)
+	}
+
 	if instance.Status.ReadyCount > 0 {
 		// remove finalizers from unused MariaDBAccount records
 		err = mariadbv1.DeleteUnusedMariaDBAccountFinalizers(
@@ -1931,6 +2086,7 @@ func (r *NeutronAPIReconciler) generateServiceSecrets(
 	templateParameters["MemcachedTLS"] = mc.GetMemcachedTLSSupport()
 	templateParameters["TimeOut"] = instance.Spec.APITimeout
 	templateParameters["QuorumQueues"] = quorumQueues
+	templateParameters["WSGI"] = instance.IsWSGI()
 
 	notificationsTransportURL, _, err := r.getTransportURL(ctx, h, instance, instance.Status.NotificationsTransportURLSecret)
 	if err != nil && !errors.Is(err, errTransportURLSecretNameNilOrEmpty) {

--- a/internal/controller/neutronapi_controller.go
+++ b/internal/controller/neutronapi_controller.go
@@ -535,7 +535,7 @@ func (r *NeutronAPIReconciler) reconcileInit(
 	//
 	// create Secret required for neutronapi and dbsync input. It contains minimal neutron config required
 	// to get the service up, user can add additional files to be added to the service.
-	err = r.generateServiceSecrets(ctx, helper, instance, &secretVars, db)
+	err = r.generateServiceSecrets(ctx, helper, instance, &secretVars, db, serviceLabels, serviceAnnotations)
 	if err != nil {
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			condition.ServiceConfigReadyCondition,
@@ -1314,7 +1314,7 @@ func (r *NeutronAPIReconciler) reconcileNormal(ctx context.Context, instance *ne
 		instance.Status.LastAppliedTopology = nil
 	}
 
-	wsgi := instance.IsWSGI()
+	wsgi := neutronapi.IsWSGIEffective(ctx, helper, instance, serviceLabels, serviceAnnotations)
 
 	deplDef, err := neutronapi.Deployment(instance, inputHash, serviceLabels, serviceAnnotations, topology, memcached, wsgi)
 	if err != nil {
@@ -2023,6 +2023,8 @@ func (r *NeutronAPIReconciler) generateServiceSecrets(
 	instance *neutronv1beta1.NeutronAPI,
 	envVars *map[string]env.Setter,
 	db *mariadbv1.Database,
+	serviceLabels map[string]string,
+	serviceAnnotations map[string]string,
 ) error {
 	// Create/update secrets from templates
 	cmLabels := labels.GetLabels(instance, labels.GetGroupLabel(neutronapi.ServiceName), map[string]string{})
@@ -2086,7 +2088,7 @@ func (r *NeutronAPIReconciler) generateServiceSecrets(
 	templateParameters["MemcachedTLS"] = mc.GetMemcachedTLSSupport()
 	templateParameters["TimeOut"] = instance.Spec.APITimeout
 	templateParameters["QuorumQueues"] = quorumQueues
-	templateParameters["WSGI"] = instance.IsWSGI()
+	templateParameters["WSGI"] = neutronapi.IsWSGIEffective(ctx, h, instance, serviceLabels, serviceAnnotations)
 
 	notificationsTransportURL, _, err := r.getTransportURL(ctx, h, instance, instance.Status.NotificationsTransportURLSecret)
 	if err != nil && !errors.Is(err, errTransportURLSecretNameNilOrEmpty) {

--- a/internal/neutronapi/const.go
+++ b/internal/neutronapi/const.go
@@ -48,6 +48,15 @@ const (
 
 	// ACConsumerFinalizer is added to AC secrets that neutron is actively consuming
 	ACConsumerFinalizer = "openstack.org/neutronapi-ac-consumer"
+
+	// RPCDeploymentSuffix is appended to the NeutronAPI name to name the
+	// neutron-rpc-server Deployment (WSGI strategy only)
+	RPCDeploymentSuffix = "rpc"
+
+	// WorkerDeploymentSuffix is appended to the NeutronAPI name to name the
+	// background worker (periodic/OVN maintenance) Deployment (WSGI strategy
+	// only)
+	WorkerDeploymentSuffix = "worker"
 )
 
 // DbsyncPropagation keeps track of the DBSync Service Propagation Type

--- a/internal/neutronapi/dbsync.go
+++ b/internal/neutronapi/dbsync.go
@@ -11,9 +11,13 @@ import (
 	"k8s.io/utils/ptr"
 )
 
-// DbSyncCommand - direct neutron-db-manage command without kolla wrapper
-const DbSyncCommand = "neutron-db-manage --config-file /usr/share/neutron/neutron-dist.conf " +
-	"--config-file /etc/neutron/neutron.conf --config-dir /etc/neutron/neutron.conf.d upgrade heads"
+// DbSyncCommand - direct neutron-db-manage command without kolla wrapper.
+// Deliberately does not pass --config-file for /usr/share/neutron/neutron-dist.conf
+// or /etc/neutron/neutron.conf: unlike kolla, this operator never materializes
+// those paths, and oslo.config aborts if an explicitly named --config-file
+// doesn't exist. --config-dir alone (loading 01-neutron.conf then
+// 02-neutron-custom.conf in order) is sufficient.
+const DbSyncCommand = "neutron-db-manage --config-dir /etc/neutron/neutron.conf.d upgrade heads"
 
 // DbSyncJob func
 func DbSyncJob(

--- a/internal/neutronapi/deployment.go
+++ b/internal/neutronapi/deployment.go
@@ -35,12 +35,16 @@ import (
 )
 
 // NeutronAPICommand is the command used to run the native neutron-server
-// process (the neutron-api container).
+// process (the neutron-api container). Only used under the legacy Eventlet
+// strategy (wsgi=false) -- under WSGI, httpd/mod_wsgi loads the API
+// in-process and this container is not created at all.
 const NeutronAPICommand = "neutron-server --config-file /usr/share/neutron/neutron-dist.conf " +
 	"--config-file /etc/neutron/neutron.conf --config-dir /etc/neutron/neutron.conf.d"
 
-// NeutronHttpdCommand is the command used to run the httpd reverse-proxy
-// (the neutron-httpd container).
+// NeutronHttpdCommand is the command used to run httpd. Under both
+// strategies httpd is the container that serves port 9696: as a reverse
+// proxy to the eventlet neutron-api process (wsgi=false), or as the
+// mod_wsgi host of the API application itself (wsgi=true).
 const NeutronHttpdCommand = "httpd -DFOREGROUND"
 
 // Deployment func
@@ -51,13 +55,17 @@ func Deployment(
 	annotations map[string]string,
 	topology *topologyv1.Topology,
 	memcached *memcachedv1.Memcached,
+	wsgi bool,
 ) (*appsv1.Deployment, error) {
 	// TODO(lucasagomes): Look into how to implement separated probes
-	// for the httpd and neutron-api containers. Right now the code uses
-	// the same liveness and readiness probes for both containers which
-	// only checks the port 9696 (NeutronPublicPort) which is the port
-	// that httpd is listening to. Ideally, we should also include a
-	// probe on port 9697 which is the port that neutron-api binds to
+	// for the httpd and neutron-api containers under the Eventlet (wsgi=false)
+	// strategy. Right now the code uses the same liveness and readiness
+	// probes for both containers which only checks the port 9696
+	// (NeutronPublicPort) which is the port that httpd is listening to.
+	// Ideally, we should also include a probe on port 9697 which is the
+	// port that neutron-api binds to. Under the WSGI (wsgi=true) strategy
+	// this isn't a gap: httpd/mod_wsgi *is* the API process, so probing
+	// port 9696 accurately reflects the API's health.
 	livenessProbe := &corev1.Probe{
 		TimeoutSeconds:      30,
 		PeriodSeconds:       30,
@@ -149,6 +157,62 @@ func Deployment(
 		apiVolumeMounts = append(apiVolumeMounts, svc.CreateVolumeMounts("ovndb")...)
 	}
 
+	// Under the WSGI strategy httpd/mod_wsgi loads the neutron API
+	// application in-process, so the httpd container needs everything the
+	// eventlet neutron-api container would otherwise mount (neutron config,
+	// OVN client certs, etc) in addition to its own httpd config/TLS mounts.
+	// There is no separate neutron-api container at all in this mode.
+	// Some mounts (e.g. the CA bundle) are deliberately added to both
+	// apiVolumeMounts and httpdVolumeMounts above so that each ends up on
+	// whichever container needs it under the Eventlet strategy, where they
+	// land in two different containers -- merged into a single container
+	// here, they must be de-duplicated by MountPath or the Deployment is
+	// rejected ("must be unique").
+	httpdContainerVolumeMounts := httpdVolumeMounts
+	if wsgi {
+		httpdContainerVolumeMounts = dedupeVolumeMountsByPath(
+			append(append([]corev1.VolumeMount{}, httpdVolumeMounts...), apiVolumeMounts...))
+		envVars["OS_NEUTRON_CONFIG_DIR"] = env.SetValue("/etc/neutron/neutron.conf.d")
+		envVars["OS_NEUTRON_CONFIG_FILES"] = env.SetValue("01-neutron.conf")
+		if instance.Spec.CustomServiceConfig != "" {
+			envVars["OS_NEUTRON_CONFIG_FILES"] = env.SetValue("01-neutron.conf;02-neutron-custom.conf")
+		}
+	}
+
+	// neutron-api (Eventlet only) is listed before neutron-httpd, matching
+	// the container order this Deployment has always used pre-WSGI. There is
+	// no functional requirement on the order -- keeping it avoids reshuffling
+	// container indexes (e.g. in `oc describe`/`oc logs` output) for existing
+	// Eventlet deployments migrating to this code.
+	containers := []corev1.Container{}
+	if !wsgi {
+		containers = append(containers, corev1.Container{
+			Name:                     ServiceName + "-api",
+			Command:                  []string{"/bin/bash"},
+			Args:                     apiArgs,
+			Image:                    instance.Spec.ContainerImage,
+			SecurityContext:          pod.RestrictiveSecurityContext(users.NeutronUID, users.NeutronGID),
+			Env:                      env.MergeEnvs([]corev1.EnvVar{}, envVars),
+			VolumeMounts:             apiVolumeMounts,
+			Resources:                instance.Spec.Resources,
+			LivenessProbe:            livenessProbe,
+			TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+		})
+	}
+	containers = append(containers, corev1.Container{
+		Name:                     ServiceName + "-httpd",
+		Command:                  []string{"/bin/bash"},
+		Args:                     httpdArgs,
+		Image:                    instance.Spec.ContainerImage,
+		SecurityContext:          pod.RestrictiveSecurityContext(users.NeutronUID, users.NeutronGID),
+		Env:                      env.MergeEnvs([]corev1.EnvVar{}, envVars),
+		VolumeMounts:             httpdContainerVolumeMounts,
+		Resources:                instance.Spec.Resources,
+		ReadinessProbe:           readinessProbe,
+		LivenessProbe:            livenessProbe,
+		TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+	})
+
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      ServiceName,
@@ -168,39 +232,39 @@ func Deployment(
 					SecurityContext:              pod.RestrictivePodSecurityContext(users.NeutronUID, users.NeutronGID),
 					ServiceAccountName:           instance.RbacResourceName(),
 					AutomountServiceAccountToken: ptr.To(false),
-					Containers: []corev1.Container{
-						{
-							Name:                     ServiceName + "-api",
-							Command:                  []string{"/bin/bash"},
-							Args:                     apiArgs,
-							Image:                    instance.Spec.ContainerImage,
-							SecurityContext:          pod.RestrictiveSecurityContext(users.NeutronUID, users.NeutronGID),
-							Env:                      env.MergeEnvs([]corev1.EnvVar{}, envVars),
-							VolumeMounts:             apiVolumeMounts,
-							Resources:                instance.Spec.Resources,
-							LivenessProbe:            livenessProbe,
-							TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
-						},
-						{
-							Name:                     ServiceName + "-httpd",
-							Command:                  []string{"/bin/bash"},
-							Args:                     httpdArgs,
-							Image:                    instance.Spec.ContainerImage,
-							SecurityContext:          pod.RestrictiveSecurityContext(users.NeutronUID, users.NeutronGID),
-							Env:                      env.MergeEnvs([]corev1.EnvVar{}, envVars),
-							VolumeMounts:             httpdVolumeMounts,
-							Resources:                instance.Spec.Resources,
-							ReadinessProbe:           readinessProbe,
-							LivenessProbe:            livenessProbe,
-							TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
-						},
-					},
-					Volumes: volumes,
+					Containers:                   containers,
+					Volumes:                      volumes,
 				},
 			},
 		},
 	}
 
+	applyPlacement(instance, deployment, topology)
+
+	return deployment, nil
+}
+
+// dedupeVolumeMountsByPath drops later entries that reuse a MountPath
+// already claimed by an earlier one. The Kubernetes API rejects a container
+// with two VolumeMounts sharing a MountPath, which can happen once mounts
+// built for two separate containers (API and httpd, under Eventlet) are
+// merged onto a single one (under WSGI).
+func dedupeVolumeMountsByPath(mounts []corev1.VolumeMount) []corev1.VolumeMount {
+	seen := make(map[string]bool, len(mounts))
+	deduped := make([]corev1.VolumeMount, 0, len(mounts))
+	for _, m := range mounts {
+		if seen[m.MountPath] {
+			continue
+		}
+		seen[m.MountPath] = true
+		deduped = append(deduped, m)
+	}
+	return deduped
+}
+
+// applyPlacement applies NodeSelector, Topology and anti-affinity rules
+// shared by all NeutronAPI-owned Deployments (API, RPC, worker).
+func applyPlacement(instance *neutronv1.NeutronAPI, deployment *appsv1.Deployment, topology *topologyv1.Topology) {
 	if instance.Spec.NodeSelector != nil {
 		deployment.Spec.Template.Spec.NodeSelector = *instance.Spec.NodeSelector
 	}
@@ -214,11 +278,9 @@ func Deployment(
 		deployment.Spec.Template.Spec.Affinity = affinity.DistributePods(
 			common.AppSelector,
 			[]string{
-				ServiceName,
+				deployment.Name,
 			},
 			corev1.LabelHostname,
 		)
 	}
-
-	return deployment, nil
 }

--- a/internal/neutronapi/imageprobe.go
+++ b/internal/neutronapi/imageprobe.go
@@ -1,0 +1,134 @@
+package neutronapi
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/job"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/pod"
+	"github.com/openstack-k8s-operators/lib-common/modules/users"
+	neutronv1beta1 "github.com/openstack-k8s-operators/neutron-operator/api/v1beta1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+)
+
+// TEMPORARY (OSPRH-33113): the wsgi annotation (NeutronWSGILabel) now
+// defaults to true on the openstack-operator side ahead of the separate,
+// global rollout of WSGI-only (Eventlet-removed) images across every
+// openstack-k8s-operators default image pin. Until that rollout completes,
+// some deployments may still resolve ContainerImage to a pre-WSGI image. In
+// that case IsWSGIEffective below falls back to the Eventlet strategy
+// regardless of what the annotation says, by inspecting the resolved image
+// for NeutronServerBinaryPath via ImageProbeJob.
+//
+// Remove this whole file and its two call sites (reverting them to
+// instance.IsWSGI()) once WSGI-only images are the default everywhere.
+
+// NeutronServerBinaryPath is only present in pre-WSGI (Eventlet-capable)
+// Neutron images. Its absence indicates a WSGI-only (Eventlet-removed) image.
+const NeutronServerBinaryPath = "/usr/bin/neutron-server"
+
+// ImageProbeCommand exits 0 if NeutronServerBinaryPath is present (a
+// pre-WSGI, Eventlet-capable image) and non-zero otherwise, so the result
+// can be read straight off the Job's Succeeded/Failed status.
+var ImageProbeCommand = fmt.Sprintf("test -f %s", NeutronServerBinaryPath)
+
+// imageProbeHash is only used as the job.NewJob jobType for log messages.
+const imageProbeHash = "imageprobe"
+
+// ImageProbeJobName returns the name of the ImageProbeJob for cr.
+func ImageProbeJobName(cr *neutronv1beta1.NeutronAPI) string {
+	return cr.Name + "-image-probe"
+}
+
+// ImageProbeJob builds the Job used to detect whether cr.Spec.ContainerImage
+// is a pre-WSGI (Eventlet-capable) image, by checking for the presence of
+// NeutronServerBinaryPath.
+func ImageProbeJob(
+	cr *neutronv1beta1.NeutronAPI,
+	labels map[string]string,
+	annotations map[string]string,
+) *batchv1.Job {
+	name := ImageProbeJobName(cr)
+
+	probeJob := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   cr.Namespace,
+			Annotations: annotations,
+			Labels:      labels,
+		},
+		Spec: batchv1.JobSpec{
+			// A single attempt is enough: the probe command is a
+			// deterministic file check, not something that benefits from
+			// retries.
+			BackoffLimit: ptr.To(int32(0)),
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					RestartPolicy:                corev1.RestartPolicyNever,
+					ServiceAccountName:           cr.RbacResourceName(),
+					AutomountServiceAccountToken: ptr.To(false),
+					SecurityContext:              pod.RestrictivePodSecurityContext(users.NeutronUID, users.NeutronGID),
+					Containers: []corev1.Container{
+						{
+							Name:            name,
+							Command:         []string{"/bin/bash"},
+							Args:            []string{"-c", ImageProbeCommand},
+							Image:           cr.Spec.ContainerImage,
+							SecurityContext: pod.RestrictiveSecurityContext(users.NeutronUID, users.NeutronGID),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if cr.Spec.NodeSelector != nil {
+		probeJob.Spec.Template.Spec.NodeSelector = *cr.Spec.NodeSelector
+	}
+
+	return probeJob
+}
+
+// IsWSGIEffective returns the deployment strategy to actually use, layering
+// a runtime safety net on top of instance.IsWSGI(): if the wsgi annotation
+// says wsgi, it fires off (but does not block reconcile on) ImageProbeJob
+// and falls back to the Eventlet strategy once that Job finds
+// NeutronServerBinaryPath in the resolved ContainerImage.
+//
+// The probe result is read straight off the Job's own status on every call
+// instead of being persisted on the NeutronAPI: job.DoJob already tracks
+// whether ImageProbeJob needs to be (re)created via a hash stored as an
+// annotation on the Job itself, so no CR status/hash bookkeeping is needed
+// here. Until the Job completes, this just keeps returning instance.IsWSGI().
+func IsWSGIEffective(
+	ctx context.Context,
+	h *helper.Helper,
+	instance *neutronv1beta1.NeutronAPI,
+	labels map[string]string,
+	annotations map[string]string,
+) bool {
+	if !instance.IsWSGI() {
+		return false
+	}
+
+	probeJobDef := ImageProbeJob(instance, labels, annotations)
+	probeJob := job.NewJob(probeJobDef, imageProbeHash, instance.Spec.PreserveJobs, time.Duration(5)*time.Second, "")
+	if _, err := probeJob.DoJob(ctx, h); err != nil {
+		// A Failed image-probe Job just means NeutronServerBinaryPath was
+		// not found (a WSGI-only image) -- not a real error.
+		h.GetLogger().Info(fmt.Sprintf("Image probe Job %s: %v", probeJobDef.Name, err))
+	}
+
+	existingProbeJob := &batchv1.Job{}
+	err := h.GetClient().Get(ctx, types.NamespacedName{Name: probeJobDef.Name, Namespace: instance.Namespace}, existingProbeJob)
+	if err == nil && existingProbeJob.Status.Succeeded > 0 {
+		return false
+	}
+	return true
+}

--- a/internal/neutronapi/workers.go
+++ b/internal/neutronapi/workers.go
@@ -1,0 +1,236 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package neutronapi
+
+import (
+	"fmt"
+
+	memcachedv1 "github.com/openstack-k8s-operators/infra-operator/apis/memcached/v1beta1"
+	topologyv1 "github.com/openstack-k8s-operators/infra-operator/apis/topology/v1beta1"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/env"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/pod"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/tls"
+	"github.com/openstack-k8s-operators/lib-common/modules/users"
+	neutronv1 "github.com/openstack-k8s-operators/neutron-operator/api/v1beta1"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+)
+
+// These commands deliberately do not pass --config-file for
+// /usr/share/neutron/neutron-dist.conf or /etc/neutron/neutron.conf: unlike
+// kolla, this operator never materializes those paths, and oslo.config
+// aborts if an explicitly named --config-file doesn't exist. --config-dir
+// alone (loading 01-neutron.conf then 02-neutron-custom.conf in order) is
+// sufficient -- see DbSyncCommand and OSPRH-28742's db-sync-config.json.
+
+// NeutronRPCCommand runs the neutron-rpc-server process, which handles AMQP
+// RPC calls (e.g. from neutron agents) independently from the WSGI API
+// process. WSGI strategy only.
+const NeutronRPCCommand = "neutron-rpc-server --config-dir /etc/neutron/neutron.conf.d"
+
+// NeutronPeriodicWorkersCommand runs neutron's periodic background tasks
+// (e.g. stale resource cleanup). WSGI strategy only.
+const NeutronPeriodicWorkersCommand = "neutron-periodic-workers --config-dir /etc/neutron/neutron.conf.d"
+
+// NeutronOVNMaintenanceCommand runs the ML2/OVN mechanism driver's
+// maintenance tasks. WSGI strategy only, and only when ovn is one of the
+// configured Ml2MechanismDrivers.
+const NeutronOVNMaintenanceCommand = "neutron-ovn-maintenance-worker --config-dir /etc/neutron/neutron.conf.d"
+
+// workerVolumesAndMounts builds the Volumes/VolumeMounts shared by the
+// non-API Deployments (neutron-rpc, neutron-worker): neutron.conf.d, CA
+// bundle, memcached mTLS and the OVN DB client cert. This mirrors what
+// Deployment() mounts into the neutron-api container, minus the
+// httpd-specific config/TLS mounts those processes don't need.
+func workerVolumesAndMounts(
+	instance *neutronv1.NeutronAPI,
+	memcached *memcachedv1.Memcached,
+) ([]corev1.Volume, []corev1.VolumeMount) {
+	volumes := GetVolumes(instance.Name, instance.Spec.ExtraMounts, NeutronAPIPropagation)
+	policyOverwrite := len(instance.Spec.DefaultConfigOverwrite["policy.yaml"]) > 0
+	volumeMounts := GetVolumeMounts(instance.Spec.ExtraMounts, NeutronAPIPropagation, policyOverwrite)
+
+	if instance.Spec.TLS.CaBundleSecretName != "" {
+		volumes = append(volumes, instance.Spec.TLS.CreateVolume())
+		volumeMounts = append(volumeMounts, instance.Spec.TLS.CreateVolumeMounts(nil)...)
+	}
+
+	if memcached.Status.MTLSCert != "" {
+		volumes = append(volumes, memcached.CreateMTLSVolume())
+		certMountPath := memcachedv1.CertPathDst
+		keyMountPath := memcachedv1.KeyPathDst
+		volumeMounts = append(volumeMounts, memcached.CreateMTLSVolumeMounts(&certMountPath, &keyMountPath)...)
+	}
+
+	if instance.IsOVNEnabled() && instance.Spec.TLS.Ovn.Enabled() {
+		svc := tls.Service{
+			SecretName: *instance.Spec.TLS.Ovn.SecretName,
+			CertMount:  ptr.To("/etc/pki/tls/certs/ovndb.crt"),
+			KeyMount:   ptr.To("/etc/pki/tls/private/ovndb.key"),
+			CaMount:    ptr.To("/etc/pki/tls/certs/ovndbca.crt"),
+		}
+		volumes = append(volumes, svc.CreateVolume("ovndb"))
+		volumeMounts = append(volumeMounts, svc.CreateVolumeMounts("ovndb")...)
+	}
+
+	return volumes, volumeMounts
+}
+
+// RPCDeployment builds the Deployment that runs neutron-rpc-server. Callers
+// are expected to skip calling this entirely when rpc_workers=0 is set in
+// instance.Spec.CustomServiceConfig (see neutronv1.GetRPCWorkers), rather
+// than creating it with Replicas=0: the RPC worker has no HTTP endpoint to
+// scale behind, so "disabled" means "the Deployment does not exist".
+func RPCDeployment(
+	instance *neutronv1.NeutronAPI,
+	configHash string,
+	labels map[string]string,
+	annotations map[string]string,
+	topology *topologyv1.Topology,
+	memcached *memcachedv1.Memcached,
+) *appsv1.Deployment {
+	volumes, volumeMounts := workerVolumesAndMounts(instance, memcached)
+
+	envVars := map[string]env.Setter{}
+	envVars["CONFIG_HASH"] = env.SetValue(configHash)
+	envVars["OS_NEUTRON_CONFIG_DIR"] = env.SetValue("/etc/neutron/neutron.conf.d")
+	envVars["OS_NEUTRON_CONFIG_FILES"] = env.SetValue("01-neutron.conf")
+	if instance.Spec.CustomServiceConfig != "" {
+		envVars["OS_NEUTRON_CONFIG_FILES"] = env.SetValue("01-neutron.conf;02-neutron-custom.conf")
+	}
+
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-%s", ServiceName, RPCDeploymentSuffix),
+			Namespace: instance.Namespace,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: labels,
+			},
+			Replicas: ptr.To(int32(1)),
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: annotations,
+					Labels:      labels,
+				},
+				Spec: corev1.PodSpec{
+					SecurityContext:              pod.RestrictivePodSecurityContext(users.NeutronUID, users.NeutronGID),
+					ServiceAccountName:           instance.RbacResourceName(),
+					AutomountServiceAccountToken: ptr.To(false),
+					Containers: []corev1.Container{
+						{
+							Name:                     ServiceName + "-" + RPCDeploymentSuffix,
+							Command:                  []string{"/bin/bash"},
+							Args:                     []string{"-c", NeutronRPCCommand},
+							Image:                    instance.Spec.ContainerImage,
+							SecurityContext:          pod.RestrictiveSecurityContext(users.NeutronUID, users.NeutronGID),
+							Env:                      env.MergeEnvs([]corev1.EnvVar{}, envVars),
+							VolumeMounts:             volumeMounts,
+							Resources:                instance.Spec.Resources,
+							TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+						},
+					},
+					Volumes: volumes,
+				},
+			},
+		},
+	}
+
+	applyPlacement(instance, deployment, topology)
+	return deployment
+}
+
+// WorkerDeployment builds the Deployment that runs neutron's background
+// workers: periodic tasks, plus (when ovn is a configured ML2 mechanism
+// driver) the OVN maintenance worker, as separate containers of the same
+// pod. Unlike RPCDeployment there is no customServiceConfig knob to disable
+// this Deployment; the OVN container is simply omitted when OVN is disabled.
+func WorkerDeployment(
+	instance *neutronv1.NeutronAPI,
+	configHash string,
+	labels map[string]string,
+	annotations map[string]string,
+	topology *topologyv1.Topology,
+	memcached *memcachedv1.Memcached,
+) *appsv1.Deployment {
+	volumes, volumeMounts := workerVolumesAndMounts(instance, memcached)
+
+	envVars := map[string]env.Setter{}
+	envVars["CONFIG_HASH"] = env.SetValue(configHash)
+	envVars["OS_NEUTRON_CONFIG_DIR"] = env.SetValue("/etc/neutron/neutron.conf.d")
+	envVars["OS_NEUTRON_CONFIG_FILES"] = env.SetValue("01-neutron.conf")
+	if instance.Spec.CustomServiceConfig != "" {
+		envVars["OS_NEUTRON_CONFIG_FILES"] = env.SetValue("01-neutron.conf;02-neutron-custom.conf")
+	}
+
+	containers := []corev1.Container{
+		{
+			Name:                     ServiceName + "-periodic-workers",
+			Command:                  []string{"/bin/bash"},
+			Args:                     []string{"-c", NeutronPeriodicWorkersCommand},
+			Image:                    instance.Spec.ContainerImage,
+			SecurityContext:          pod.RestrictiveSecurityContext(users.NeutronUID, users.NeutronGID),
+			Env:                      env.MergeEnvs([]corev1.EnvVar{}, envVars),
+			VolumeMounts:             volumeMounts,
+			Resources:                instance.Spec.Resources,
+			TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+		},
+	}
+
+	if instance.IsOVNEnabled() {
+		containers = append(containers, corev1.Container{
+			Name:                     ServiceName + "-ovn-maintenance-worker",
+			Command:                  []string{"/bin/bash"},
+			Args:                     []string{"-c", NeutronOVNMaintenanceCommand},
+			Image:                    instance.Spec.ContainerImage,
+			SecurityContext:          pod.RestrictiveSecurityContext(users.NeutronUID, users.NeutronGID),
+			Env:                      env.MergeEnvs([]corev1.EnvVar{}, envVars),
+			VolumeMounts:             volumeMounts,
+			Resources:                instance.Spec.Resources,
+			TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+		})
+	}
+
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-%s", ServiceName, WorkerDeploymentSuffix),
+			Namespace: instance.Namespace,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: labels,
+			},
+			Replicas: ptr.To(int32(1)),
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: annotations,
+					Labels:      labels,
+				},
+				Spec: corev1.PodSpec{
+					SecurityContext:              pod.RestrictivePodSecurityContext(users.NeutronUID, users.NeutronGID),
+					ServiceAccountName:           instance.RbacResourceName(),
+					AutomountServiceAccountToken: ptr.To(false),
+					Containers:                   containers,
+					Volumes:                      volumes,
+				},
+			},
+		},
+	}
+
+	applyPlacement(instance, deployment, topology)
+	return deployment
+}

--- a/templates/neutronapi/config/01-neutron.conf
+++ b/templates/neutronapi/config/01-neutron.conf
@@ -10,8 +10,20 @@ service_plugins = qos,trunk,segments,port_forwarding,log
 {{ end }}
 dns_domain = openstackgate.local
 dhcp_agent_notification = false
+{{ if .WSGI -}}
+# Under the WSGI strategy, httpd/mod_wsgi manages API worker processes
+# (WSGIDaemonProcess), so neutron-server itself should not fork any API
+# workers. rpc_workers is intentionally left unset here (neutron defaults to
+# a positive value) so that the dedicated neutron-rpc-server Deployment,
+# which shares this same config, still forks its own RPC workers -- unless
+# the user overrides rpc_workers via customServiceConfig, which the operator
+# also honors when deciding whether to create the neutron-rpc Deployment at
+# all (rpc_workers=0 disables it).
+api_workers = 0
+{{ else -}}
 api_workers = 2
 rpc_workers = 1
+{{ end -}}
 
 [database]
 connection=mysql+pymysql://{{ .DbUser }}:{{ .DbPassword }}@{{ .DbHost }}/{{ .Db }}?read_default_file=/etc/my.cnf

--- a/templates/neutronapi/httpd/10-neutron-httpd.conf
+++ b/templates/neutronapi/httpd/10-neutron-httpd.conf
@@ -20,11 +20,22 @@
   RequestHeader setIfEmpty X-Forwarded-Proto "http"
 {{- end }}
 
-  ## Proxy rules
+{{- if $.WSGI }}
+  ## WSGI configuration: httpd/mod_wsgi loads and serves the neutron API
+  ## application in-process, there is no eventlet neutron-api backend to
+  ## proxy to.
+  WSGIDaemonProcess {{ $endpt }} processes=2 threads=1 user=neutron group=neutron display-name={{ $endpt }}
+  WSGIProcessGroup {{ $endpt }}
+  WSGIScriptAlias / /var/www/cgi-bin/neutron/neutron-wsgi
+  WSGIApplicationGroup %{GLOBAL}
+  WSGIPassAuthorization On
+{{- else }}
+  ## Proxy rules (Eventlet backend)
   ProxyRequests Off
   ProxyPreserveHost On
   ProxyPass / http://localhost:9697/ retry=10
   ProxyPassReverse / http://localhost:9697/
+{{- end }}
 
 {{- if $vhost.TLS }}
   SetEnvIf X-Forwarded-Proto https HTTPS=1

--- a/templates/neutronapi/httpd/httpd.conf
+++ b/templates/neutronapi/httpd/httpd.conf
@@ -22,5 +22,3 @@ SetEnvIf X-Forwarded-For "^.*\..*\..*\..*" forwarded
 CustomLog /dev/stdout combined env=!forwarded
 CustomLog /dev/stdout proxy env=forwarded
 ErrorLog /dev/stderr
-
-Include conf.d/10-neutron.conf

--- a/test/functional/base_test.go
+++ b/test/functional/base_test.go
@@ -86,6 +86,24 @@ func CreateNeutronAPI(namespace string, NeutronAPIName string, spec map[string]a
 	return th.CreateUnstructured(raw)
 }
 
+// CreateNeutronAPIWithAnnotations is CreateNeutronAPI plus metadata
+// annotations, e.g. to set neutron.openstack.org/wsgi in tests.
+func CreateNeutronAPIWithAnnotations(namespace string, NeutronAPIName string, spec map[string]any, annotations map[string]string) client.Object {
+
+	raw := map[string]any{
+		"apiVersion": "neutron.openstack.org/v1beta1",
+		"kind":       "NeutronAPI",
+		"metadata": map[string]any{
+			"name":        NeutronAPIName,
+			"namespace":   namespace,
+			"annotations": annotations,
+		},
+		"spec": spec,
+	}
+
+	return th.CreateUnstructured(raw)
+}
+
 func GetNeutronAPI(name types.NamespacedName) *neutronv1.NeutronAPI {
 	instance := &neutronv1.NeutronAPI{}
 	Eventually(func(g Gomega) {

--- a/test/functional/neutronapi_controller_test.go
+++ b/test/functional/neutronapi_controller_test.go
@@ -493,10 +493,18 @@ func getNeutronAPIControllerSuite(ml2MechanismDrivers []string) func() {
 				configData := th.GetSecret(secret)
 				Expect(configData).ShouldNot(BeNil())
 				conf := string(configData.Data["01-neutron.conf"])
+				// WSGI is the default strategy (no neutron.openstack.org/wsgi
+				// annotation set in this test): api_workers is forced to 0
+				// since httpd/mod_wsgi manages API worker processes, and
+				// rpc_workers is left unset so neutron-rpc-server uses its
+				// own default worker count.
 				Expect(conf).Should(
-					ContainSubstring("api_workers = 2"))
-				Expect(conf).Should(
-					ContainSubstring("rpc_workers = 1"))
+					ContainSubstring("api_workers = 0"))
+				// Only check for an actual "rpc_workers =" assignment line;
+				// the WSGI branch of the template also has an explanatory
+				// comment mentioning "rpc_workers" in prose.
+				Expect(conf).ShouldNot(
+					ContainSubstring("rpc_workers ="))
 				Expect(conf).Should(
 					ContainSubstring("mysql_wsrep_sync_wait = 1"))
 
@@ -1115,18 +1123,18 @@ func getNeutronAPIControllerSuite(ml2MechanismDrivers []string) func() {
 				)
 				Expect(int(*deployment.Spec.Replicas)).To(Equal(1))
 				Expect(deployment.Spec.Template.Spec.Volumes).To(HaveLen(3))
-				Expect(deployment.Spec.Template.Spec.Containers).To(HaveLen(2))
+				// WSGI is the default strategy (no neutron.openstack.org/wsgi
+				// annotation set in this test): httpd/mod_wsgi loads the API
+				// in-process, so there is a single container mounting both
+				// the neutron config and the httpd config volumes.
+				Expect(deployment.Spec.Template.Spec.Containers).To(HaveLen(1))
 
-				nSvcContainer := deployment.Spec.Template.Spec.Containers[0]
-				Expect(nSvcContainer.LivenessProbe.HTTPGet.Port.IntVal).To(Equal(int32(9696)))
-				Expect(nSvcContainer.VolumeMounts).To(HaveLen(3))
-				Expect(nSvcContainer.Image).To(Equal(util.GetEnvVar("RELATED_IMAGE_NEUTRON_API_IMAGE_URL_DEFAULT", neutronv1.NeutronAPIContainerImage)))
-
-				nHttpdProxyContainer := deployment.Spec.Template.Spec.Containers[1]
-				Expect(nHttpdProxyContainer.LivenessProbe.HTTPGet.Port.IntVal).To(Equal(int32(9696)))
-				Expect(nHttpdProxyContainer.ReadinessProbe.HTTPGet.Port.IntVal).To(Equal(int32(9696)))
-				Expect(nHttpdProxyContainer.VolumeMounts).To(HaveLen(4))
-				Expect(nHttpdProxyContainer.Image).To(Equal(util.GetEnvVar("RELATED_IMAGE_NEUTRON_API_IMAGE_URL_DEFAULT", neutronv1.NeutronAPIContainerImage)))
+				httpdContainer := deployment.Spec.Template.Spec.Containers[0]
+				Expect(httpdContainer.Name).To(Equal("neutron-httpd"))
+				Expect(httpdContainer.LivenessProbe.HTTPGet.Port.IntVal).To(Equal(int32(9696)))
+				Expect(httpdContainer.ReadinessProbe.HTTPGet.Port.IntVal).To(Equal(int32(9696)))
+				Expect(httpdContainer.VolumeMounts).To(HaveLen(7))
+				Expect(httpdContainer.Image).To(Equal(util.GetEnvVar("RELATED_IMAGE_NEUTRON_API_IMAGE_URL_DEFAULT", neutronv1.NeutronAPIContainerImage)))
 			})
 		})
 
@@ -1226,6 +1234,13 @@ func getNeutronAPIControllerSuite(ml2MechanismDrivers []string) func() {
 					condition.DeploymentReadyCondition,
 					corev1.ConditionTrue,
 				)
+
+				// WSGI is the default strategy (no neutron.openstack.org/wsgi
+				// annotation set in this test): neutron-rpc and
+				// neutron-worker also need to reach Ready for the aggregate
+				// Ready condition to go True.
+				th.SimulateDeploymentReplicaReady(types.NamespacedName{Namespace: namespace, Name: "neutron-rpc"})
+				th.SimulateDeploymentReplicaReady(types.NamespacedName{Namespace: namespace, Name: "neutron-worker"})
 
 				th.ExpectCondition(
 					neutronAPIName,
@@ -1460,25 +1475,26 @@ func getNeutronAPIControllerSuite(ml2MechanismDrivers []string) func() {
 					th.AssertVolumeExists(ovnDbCertSecretName.Name, deployment.Spec.Template.Spec.Volumes)
 				}
 
-				// svc container ca cert
-				nSvcContainer := deployment.Spec.Template.Spec.Containers[0]
-				th.AssertVolumeMountPathExists(caBundleSecretName.Name, "", "tls-ca-bundle.pem", nSvcContainer.VolumeMounts)
+				// WSGI is the default strategy (no neutron.openstack.org/wsgi
+				// annotation set in this test): httpd/mod_wsgi loads the API
+				// in-process, so all cert mounts (API-side OVN certs,
+				// httpd-side endpoint certs, and the shared CA bundle) land
+				// on the single httpd container.
+				httpdContainer := deployment.Spec.Template.Spec.Containers[0]
+				th.AssertVolumeMountPathExists(caBundleSecretName.Name, "", "tls-ca-bundle.pem", httpdContainer.VolumeMounts)
 				if isOVNEnabled {
-					th.AssertVolumeMountPathExists(ovnDbCertSecretName.Name, "", "tls.key", nSvcContainer.VolumeMounts)
-					th.AssertVolumeMountPathExists(ovnDbCertSecretName.Name, "", "tls.crt", nSvcContainer.VolumeMounts)
-					th.AssertVolumeMountPathExists(ovnDbCertSecretName.Name, "", "ca.crt", nSvcContainer.VolumeMounts)
+					th.AssertVolumeMountPathExists(ovnDbCertSecretName.Name, "", "tls.key", httpdContainer.VolumeMounts)
+					th.AssertVolumeMountPathExists(ovnDbCertSecretName.Name, "", "tls.crt", httpdContainer.VolumeMounts)
+					th.AssertVolumeMountPathExists(ovnDbCertSecretName.Name, "", "ca.crt", httpdContainer.VolumeMounts)
 				}
 
-				// httpd container certs
-				nHttpdProxyContainer := deployment.Spec.Template.Spec.Containers[1]
-				th.AssertVolumeMountPathExists(publicCertSecretName.Name, "", "tls.key", nHttpdProxyContainer.VolumeMounts)
-				th.AssertVolumeMountPathExists(publicCertSecretName.Name, "", "tls.crt", nHttpdProxyContainer.VolumeMounts)
-				th.AssertVolumeMountPathExists(internalCertSecretName.Name, "", "tls.key", nHttpdProxyContainer.VolumeMounts)
-				th.AssertVolumeMountPathExists(internalCertSecretName.Name, "", "tls.crt", nHttpdProxyContainer.VolumeMounts)
-				th.AssertVolumeMountPathExists(caBundleSecretName.Name, "", "tls-ca-bundle.pem", nHttpdProxyContainer.VolumeMounts)
+				th.AssertVolumeMountPathExists(publicCertSecretName.Name, "", "tls.key", httpdContainer.VolumeMounts)
+				th.AssertVolumeMountPathExists(publicCertSecretName.Name, "", "tls.crt", httpdContainer.VolumeMounts)
+				th.AssertVolumeMountPathExists(internalCertSecretName.Name, "", "tls.key", httpdContainer.VolumeMounts)
+				th.AssertVolumeMountPathExists(internalCertSecretName.Name, "", "tls.crt", httpdContainer.VolumeMounts)
 
-				Expect(nHttpdProxyContainer.ReadinessProbe.HTTPGet.Scheme).To(Equal(corev1.URISchemeHTTPS))
-				Expect(nHttpdProxyContainer.LivenessProbe.HTTPGet.Scheme).To(Equal(corev1.URISchemeHTTPS))
+				Expect(httpdContainer.ReadinessProbe.HTTPGet.Scheme).To(Equal(corev1.URISchemeHTTPS))
+				Expect(httpdContainer.LivenessProbe.HTTPGet.Scheme).To(Equal(corev1.URISchemeHTTPS))
 
 				secret := types.NamespacedName{
 					Namespace: neutronAPIName.Namespace,
@@ -1488,10 +1504,18 @@ func getNeutronAPIControllerSuite(ml2MechanismDrivers []string) func() {
 				configData := th.GetSecret(secret)
 				Expect(configData).ShouldNot(BeNil())
 				conf := string(configData.Data["01-neutron.conf"])
+				// WSGI is the default strategy (no neutron.openstack.org/wsgi
+				// annotation set in this test): api_workers is forced to 0
+				// since httpd/mod_wsgi manages API worker processes, and
+				// rpc_workers is left unset so neutron-rpc-server uses its
+				// own default worker count.
 				Expect(conf).Should(
-					ContainSubstring("api_workers = 2"))
-				Expect(conf).Should(
-					ContainSubstring("rpc_workers = 1"))
+					ContainSubstring("api_workers = 0"))
+				// Only check for an actual "rpc_workers =" assignment line;
+				// the WSGI branch of the template also has an explanatory
+				// comment mentioning "rpc_workers" in prose.
+				Expect(conf).ShouldNot(
+					ContainSubstring("rpc_workers ="))
 				Expect(conf).Should(
 					ContainSubstring("mysql_wsrep_sync_wait = 1"))
 
@@ -1570,6 +1594,125 @@ func getNeutronAPIControllerSuite(ml2MechanismDrivers []string) func() {
 						).Spec.Template.Spec.Containers[0].Env, "CONFIG_HASH", "")
 					g.Expect(newHash).NotTo(BeEmpty())
 					g.Expect(newHash).NotTo(Equal(originalHash))
+				}, timeout, interval).Should(Succeed())
+			})
+		})
+
+		When("A NeutronAPI is created with TLS and the WSGI strategy enabled", func() {
+			BeforeEach(func() {
+				spec["tls"] = map[string]any{
+					"api": map[string]any{
+						"internal": map[string]any{
+							"secretName": InternalCertSecretName,
+						},
+						"public": map[string]any{
+							"secretName": PublicCertSecretName,
+						},
+					},
+					"caBundleSecretName": CABundleSecretName,
+					"ovn": map[string]any{
+						"secretName": InternalCertSecretName,
+					},
+				}
+				DeferCleanup(th.DeleteInstance, CreateNeutronAPIWithAnnotations(
+					neutronAPIName.Namespace, neutronAPIName.Name, spec,
+					map[string]string{"neutron.openstack.org/wsgi": "true"}))
+
+				DeferCleanup(k8sClient.Delete, ctx, th.CreateCABundleSecret(caBundleSecretName))
+				DeferCleanup(k8sClient.Delete, ctx, th.CreateCertSecret(internalCertSecretName))
+				DeferCleanup(k8sClient.Delete, ctx, th.CreateCertSecret(publicCertSecretName))
+				DeferCleanup(k8sClient.Delete, ctx, CreateNeutronAPISecret(namespace, SecretName))
+				DeferCleanup(
+					mariadb.DeleteDBService,
+					mariadb.CreateDBService(
+						namespace,
+						GetNeutronAPI(neutronAPIName).Spec.DatabaseInstance,
+						corev1.ServiceSpec{
+							Ports: []corev1.ServicePort{{Port: 3306}},
+						},
+					),
+				)
+				SimulateTransportURLReady(apiTransportURLName)
+				DeferCleanup(infra.DeleteMemcached, infra.CreateMemcached(namespace, "memcached", memcachedSpec))
+				infra.SimulateTLSMemcachedReady(memcachedName)
+				DeferCleanup(DeleteOVNDBClusters, CreateOVNDBClusters(namespace))
+				DeferCleanup(keystone.DeleteKeystoneAPI, keystone.CreateKeystoneAPI(namespace))
+				mariadb.SimulateMariaDBAccountCompleted(types.NamespacedName{Namespace: namespace, Name: GetNeutronAPI(neutronAPIName).Spec.DatabaseAccount})
+				mariadb.SimulateMariaDBTLSDatabaseCompleted(types.NamespacedName{Namespace: namespace, Name: neutronapi.Database})
+				th.SimulateJobSuccess(neutronDBSyncJobName)
+				keystone.SimulateKeystoneServiceReady(types.NamespacedName{Namespace: namespace, Name: "neutron"})
+				keystone.SimulateKeystoneEndpointReady(types.NamespacedName{Namespace: namespace, Name: "neutron"})
+			})
+
+			// Regression test: with both TLS (CA bundle) and the WSGI
+			// strategy enabled, the httpd container used to end up with the
+			// CA bundle VolumeMount twice (once from the mounts built for
+			// the eventlet neutron-api container, once from httpd's own),
+			// which the Kubernetes API rejects with "must be unique" and
+			// the Deployment never gets created.
+			It("creates a single-container Deployment without duplicate VolumeMounts", func() {
+				th.ExpectCondition(
+					neutronAPIName,
+					ConditionGetterFunc(NeutronAPIConditionGetter),
+					condition.TLSInputReadyCondition,
+					corev1.ConditionTrue,
+				)
+
+				deployment := th.GetDeployment(
+					types.NamespacedName{
+						Namespace: neutronAPIName.Namespace,
+						Name:      "neutron",
+					},
+				)
+
+				Expect(deployment.Spec.Template.Spec.Containers).To(HaveLen(1))
+				httpdContainer := deployment.Spec.Template.Spec.Containers[0]
+				Expect(httpdContainer.Name).To(Equal("neutron-httpd"))
+
+				seenPaths := map[string]int{}
+				for _, m := range httpdContainer.VolumeMounts {
+					seenPaths[m.MountPath]++
+				}
+				for path, count := range seenPaths {
+					Expect(count).To(Equal(1), "MountPath %s must be unique, got %d", path, count)
+				}
+
+				th.AssertVolumeMountPathExists(caBundleSecretName.Name, "", "tls-ca-bundle.pem", httpdContainer.VolumeMounts)
+				if isOVNEnabled {
+					th.AssertVolumeMountPathExists(ovnDbCertSecretName.Name, "", "tls.key", httpdContainer.VolumeMounts)
+				}
+				th.AssertVolumeMountPathExists(publicCertSecretName.Name, "", "tls.crt", httpdContainer.VolumeMounts)
+				th.AssertVolumeMountPathExists(internalCertSecretName.Name, "", "tls.crt", httpdContainer.VolumeMounts)
+			})
+
+			// Regression test: envtest never runs a real Deployment
+			// controller, so right after neutron-rpc/neutron-worker are
+			// created their Status.ObservedGeneration never catches up to
+			// Generation. NeutronRPCReadyCondition/NeutronWorkerReadyCondition
+			// must still show up as non-true in this state -- not be absent
+			// -- otherwise AllSubConditionIsTrue() would ignore them and the
+			// aggregate Ready condition could go True before either child
+			// Deployment has actually rolled out.
+			It("keeps the RPC and worker conditions present and non-true while their Deployments are not yet observed", func() {
+				th.GetDeployment(
+					types.NamespacedName{Namespace: neutronAPIName.Namespace, Name: "neutron-rpc"},
+				)
+				th.GetDeployment(
+					types.NamespacedName{Namespace: neutronAPIName.Namespace, Name: "neutron-worker"},
+				)
+
+				Eventually(func(g Gomega) {
+					conditions := NeutronAPIConditionGetter(neutronAPIName)
+
+					rpcCond := conditions.Get(neutronv1.NeutronRPCReadyCondition)
+					g.Expect(rpcCond).NotTo(BeNil())
+					g.Expect(rpcCond.Status).NotTo(Equal(corev1.ConditionTrue))
+
+					workerCond := conditions.Get(neutronv1.NeutronWorkerReadyCondition)
+					g.Expect(workerCond).NotTo(BeNil())
+					g.Expect(workerCond.Status).NotTo(Equal(corev1.ConditionTrue))
+
+					g.Expect(conditions.IsTrue(condition.ReadyCondition)).To(BeFalse())
 				}, timeout, interval).Should(Succeed())
 			})
 		})
@@ -1826,12 +1969,16 @@ func getNeutronAPIControllerSuite(ml2MechanismDrivers []string) func() {
 				dp := th.GetDeployment(neutronDeploymentName)
 				// Check the resulting deployment fields
 				Expect(dp.Spec.Template.Spec.Volumes).To(HaveLen(4))
-				Expect(dp.Spec.Template.Spec.Containers).To(HaveLen(2))
+				// WSGI is the default strategy (no neutron.openstack.org/wsgi
+				// annotation set in this test): a single httpd container
+				// mounts both its own 4 base mounts and the api container's
+				// 3 base mounts + 1 extraMount.
+				Expect(dp.Spec.Template.Spec.Containers).To(HaveLen(1))
 				// Get the neutron container
 				container := dp.Spec.Template.Spec.Containers[0]
 				// Fail if neutron doesn't have the right number of VolumeMounts
 				// entries
-				Expect(container.VolumeMounts).To(HaveLen(4))
+				Expect(container.VolumeMounts).To(HaveLen(8))
 				// Inspect VolumeMounts and make sure we have the Foo MountPath
 				// provided through extraMounts
 				th.AssertVolumeMountPathExists(neutronExtraMountsSecretName,
@@ -2292,6 +2439,18 @@ func getNeutronAPIControllerSuite(ml2MechanismDrivers []string) func() {
 					Namespace: namespace,
 					Name:      "neutron",
 				})
+				// WSGI is the default strategy (no neutron.openstack.org/wsgi
+				// annotation set in this test): neutron-rpc and
+				// neutron-worker also need to reach Ready for the aggregate
+				// Ready condition to go True.
+				th.SimulateDeploymentReplicaReady(types.NamespacedName{
+					Namespace: namespace,
+					Name:      "neutron-rpc",
+				})
+				th.SimulateDeploymentReplicaReady(types.NamespacedName{
+					Namespace: namespace,
+					Name:      "neutron-worker",
+				})
 				keystone.SimulateKeystoneServiceReady(types.NamespacedName{
 					Namespace: namespace,
 					Name:      "neutron",
@@ -2338,6 +2497,20 @@ func getNeutronAPIControllerSuite(ml2MechanismDrivers []string) func() {
 					th.SimulateDeploymentReplicaReady(types.NamespacedName{
 						Namespace: namespace,
 						Name:      "neutron",
+					})
+					// WSGI is the default strategy (no
+					// neutron.openstack.org/wsgi annotation set in this
+					// test): the AC secret rotation bumps the Deployments'
+					// config hash/generation again, so neutron-rpc and
+					// neutron-worker need to be re-simulated as ready for
+					// AllSubConditionIsTrue() to allow the finalizer move.
+					th.SimulateDeploymentReplicaReady(types.NamespacedName{
+						Namespace: namespace,
+						Name:      "neutron-rpc",
+					})
+					th.SimulateDeploymentReplicaReady(types.NamespacedName{
+						Namespace: namespace,
+						Name:      "neutron-worker",
 					})
 					secret := th.GetSecret(types.NamespacedName{
 						Namespace: namespace,
@@ -2530,6 +2703,12 @@ var _ = Describe("NeutronAPI Webhook", func() {
 				deplName,
 				map[string][]string{namespace + "/internalapi": {}},
 			)
+			// WSGI is the default strategy (no neutron.openstack.org/wsgi
+			// annotation set in this test): the neutron-rpc and
+			// neutron-worker Deployments also need to reach Ready for the
+			// aggregate Ready condition to go True.
+			th.SimulateDeploymentReplicaReady(types.NamespacedName{Namespace: namespace, Name: "neutron-rpc"})
+			th.SimulateDeploymentReplicaReady(types.NamespacedName{Namespace: namespace, Name: "neutron-worker"})
 
 			th.ExpectCondition(
 				neutronAPIName,

--- a/test/kuttl/common/assert_sample_deployment.yaml
+++ b/test/kuttl/common/assert_sample_deployment.yaml
@@ -64,38 +64,11 @@ spec:
               topologyKey: kubernetes.io/hostname
             weight: 100
       automountServiceAccountToken: false
+      # WSGI is the default strategy (no neutron.openstack.org/wsgi
+      # annotation set by this test): httpd/mod_wsgi loads the neutron API
+      # application in-process, so there is a single container rather than
+      # the separate eventlet neutron-api + httpd reverse-proxy pair.
       containers:
-      - command:
-        - /bin/bash
-        args:
-        - -c
-        - neutron-server --config-file /usr/share/neutron/neutron-dist.conf --config-file
-          /etc/neutron/neutron.conf --config-dir /etc/neutron/neutron.conf.d
-        imagePullPolicy: IfNotPresent
-        livenessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /
-            port: 9696
-            scheme: HTTP
-          initialDelaySeconds: 5
-          periodSeconds: 30
-          successThreshold: 1
-          timeoutSeconds: 30
-        name: neutron-api
-        resources: {}
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-          runAsGroup: 42435
-          runAsNonRoot: true
-          runAsUser: 42435
-          seccompProfile:
-            type: RuntimeDefault
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: FallbackToLogsOnError
       - command:
         - /bin/bash
         args:
@@ -147,6 +120,38 @@ spec:
       serviceAccount: neutron-neutron
       serviceAccountName: neutron-neutron
       terminationGracePeriodSeconds: 30
+status:
+  availableReplicas: 1
+  readyReplicas: 1
+  replicas: 1
+  updatedReplicas: 1
+---
+# WSGI is the default strategy: neutron-rpc-server and the background
+# workers (periodic + ovn-maintenance, since the sample uses ovn) run as
+# their own Deployments rather than inside the API pod.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: neutron-rpc
+spec:
+  replicas: 1
+status:
+  availableReplicas: 1
+  readyReplicas: 1
+  replicas: 1
+  updatedReplicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: neutron-worker
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+      - name: neutron-periodic-workers
+      - name: neutron-ovn-maintenance-worker
 status:
   availableReplicas: 1
   readyReplicas: 1

--- a/test/kuttl/tests/change_neutron_config/02-assert.yaml
+++ b/test/kuttl/tests/change_neutron_config/02-assert.yaml
@@ -8,6 +8,3 @@ commands:
         neutron_pod=$(oc get pods -n $NAMESPACE -l service=neutron --field-selector=status.phase=Running -o name|head -1)
         oc rsh -n $NAMESPACE ${neutron_pod} crudini --get /etc/neutron/neutron.conf.d/testcm.conf DEFAULT api_workers
         oc rsh -n $NAMESPACE ${neutron_pod} crudini --get /etc/neutron/neutron.conf.d/testsecret.conf DEFAULT rpc_workers
-        # Check config in pod logs
-        oc logs -n $NAMESPACE ${neutron_pod} | grep -q "api_workers.*= 1"
-        oc logs -n $NAMESPACE ${neutron_pod} | grep -q "rpc_workers.*= 0"

--- a/test/kuttl/tests/neutron_rpc_disable/01-assert.yaml
+++ b/test/kuttl/tests/neutron_rpc_disable/01-assert.yaml
@@ -1,0 +1,37 @@
+apiVersion: neutron.openstack.org/v1beta1
+kind: NeutronAPI
+metadata:
+  finalizers:
+  - openstack.org/neutronapi
+  name: neutron
+spec:
+  replicas: 1
+  ml2MechanismDrivers:
+    - openvswitch
+status:
+  readyCount: 1
+  workerReadyCount: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: neutron
+spec:
+  replicas: 1
+status:
+  availableReplicas: 1
+  readyReplicas: 1
+  replicas: 1
+  updatedReplicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: neutron-worker
+spec:
+  replicas: 1
+status:
+  availableReplicas: 1
+  readyReplicas: 1
+  replicas: 1
+  updatedReplicas: 1

--- a/test/kuttl/tests/neutron_rpc_disable/01-deploy-neutron.yaml
+++ b/test/kuttl/tests/neutron_rpc_disable/01-deploy-neutron.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: |
+      cp ../../../../config/samples/neutron_v1beta1_neutronapi_openvswitch.yaml deploy
+      oc kustomize deploy | oc apply -n $NAMESPACE -f -

--- a/test/kuttl/tests/neutron_rpc_disable/01-errors.yaml
+++ b/test/kuttl/tests/neutron_rpc_disable/01-errors.yaml
@@ -1,0 +1,10 @@
+#
+# Check for:
+#
+# No neutron-rpc Deployment
+# (rpc_workers=0)
+#
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: neutron-rpc

--- a/test/kuttl/tests/neutron_rpc_disable/02-cleanup-neutron.yaml
+++ b/test/kuttl/tests/neutron_rpc_disable/02-cleanup-neutron.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: |
+      oc kustomize deploy | oc delete -n $NAMESPACE -f -
+      rm deploy/neutron_v1beta1_neutronapi*.yaml

--- a/test/kuttl/tests/neutron_rpc_disable/02-errors.yaml
+++ b/test/kuttl/tests/neutron_rpc_disable/02-errors.yaml
@@ -1,0 +1,28 @@
+#
+# Check for:
+#
+# No NeutronAPI CR
+# No neutron/neutron-worker Deployments
+# No neutron-rpc Deployment ever (rpc_workers=0 for the whole test)
+#
+apiVersion: neutron.openstack.org/v1beta1
+kind: NeutronAPI
+metadata:
+  finalizers:
+  - openstack.org/neutronapi
+  name: neutron
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: neutron
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: neutron-rpc
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: neutron-worker

--- a/test/kuttl/tests/neutron_rpc_disable/deploy/kustomization.yaml
+++ b/test/kuttl/tests/neutron_rpc_disable/deploy/kustomization.yaml
@@ -1,0 +1,18 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ./neutron_v1beta1_neutronapi_openvswitch.yaml
+patches:
+- patch: |-
+    - op: replace
+      path: /spec/secret
+      value: osp-secret
+    - op: remove
+      path: /metadata/namespace
+    - op: add
+      path: /spec/customServiceConfig
+      value: |
+        [DEFAULT]
+        rpc_workers = 0
+  target:
+    kind: NeutronAPI

--- a/test/kuttl/tests/neutron_tls/01-assert.yaml
+++ b/test/kuttl/tests/neutron_tls/01-assert.yaml
@@ -30,28 +30,14 @@ spec:
       labels:
         service: neutron
     spec:
+      # WSGI is the default strategy (no neutron.openstack.org/wsgi
+      # annotation set by this test): httpd/mod_wsgi loads the neutron API
+      # application in-process, so there is a single container mounting
+      # both its own volumes and the neutron config volumes. The CA bundle
+      # mount is only listed once here even though it's built into both the
+      # httpd and api mount lists internally -- deployment.go de-duplicates
+      # by MountPath when merging them onto this one container.
       containers:
-      - args:
-        - -c
-        - neutron-server --config-file /usr/share/neutron/neutron-dist.conf --config-file
-          /etc/neutron/neutron.conf --config-dir /etc/neutron/neutron.conf.d
-        volumeMounts:
-        - mountPath: /etc/neutron/neutron.conf.d/01-neutron.conf
-          name: config
-          readOnly: true
-          subPath: 01-neutron.conf
-        - mountPath: /etc/neutron/neutron.conf.d/02-neutron-custom.conf
-          name: config
-          readOnly: true
-          subPath: 02-neutron-custom.conf
-        - mountPath: /etc/my.cnf
-          name: config
-          readOnly: true
-          subPath: my.cnf
-        - mountPath: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
-          name: combined-ca-bundle
-          readOnly: true
-          subPath: tls-ca-bundle.pem
       - args:
         - -c
         - httpd -DFOREGROUND
@@ -90,6 +76,18 @@ spec:
           name: public-tls-certs
           readOnly: true
           subPath: tls.key
+        - mountPath: /etc/neutron/neutron.conf.d/01-neutron.conf
+          name: config
+          readOnly: true
+          subPath: 01-neutron.conf
+        - mountPath: /etc/neutron/neutron.conf.d/02-neutron-custom.conf
+          name: config
+          readOnly: true
+          subPath: 02-neutron-custom.conf
+        - mountPath: /etc/my.cnf
+          name: config
+          readOnly: true
+          subPath: my.cnf
       volumes:
       - name: config
         secret:

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -29,7 +29,12 @@
       cifmw_edpm_deploy_nova_compute_extra_config: |
         [DEFAULT]
         force_config_drive = false
-      cifmw_test_operator_tempest_container: openstack-tempest-all
+      # TODO: Image overrides can be dropped once default images changes to master for CI
+      cifmw_update_containers_custom_images:
+        neutronAPIImage: quay.io/openstack-s2i-containers/openstack-neutron-server:master-latest
+        edpmNeutronMetadataAgentImage: quay.io/openstack-s2i-containers/openstack-neutron-metadata-agent-ovn:master-latest
+      cifmw_test_operator_tempest_image: quay.io/openstack-s2i-containers/openstack-tempest
+      cifmw_test_operator_tempest_image_tag: master-latest
       cifmw_run_test_role: test_operator
       cifmw_test_operator_tempest_network_attachments:
         - ctlplane
@@ -39,6 +44,7 @@
             validation.run_validation true
             identity.v3_endpoint_type public
             identity.v2_admin_endpoint_type public
+            neutron_plugin_options.snat_rules_apply_to_nested_networks true
       cifmw_test_operator_tempest_include_list: |
         neutron_tempest_plugin.api
         neutron_tempest_plugin.scenario
@@ -51,3 +57,7 @@
         test_qos_dscp_create_and_update
         # Limit job runtime
         NetworkSecGroupTest
+        # Needs docker setup
+        NetworkMultipleGWTest
+        # TypeError: NeutronTempestPluginException.__init__() takes 1 positional argument but 2 were given
+        L3AgentSchedulerTestJSON


### PR DESCRIPTION
OpenStack Master removes Eventlet from neutron-server, requiring the API
to run under httpd/mod_wsgi and RPC/background work to move to their own
processes. Introduce this as an opt-in strategy, gated by the
neutron.openstack.org/wsgi annotation defaulting to the legacy Eventlet strategy
when absent so upgrading the operator alone never changes an existing
deployment's behavior.

When wsgi=true:
- the "neutron" Deployment runs a single httpd/mod_wsgi container
  instead of the eventlet neutron-api + httpd reverse-proxy pair
- a new "neutron-rpc" Deployment runs neutron-rpc-server, and is skipped
  entirely when rpc_workers=0 is set in customServiceConfig
- a new "neutron-worker" Deployment runs neutron-periodic-workers and,
  when OVN is enabled, neutron-ovn-maintenance-worker

Default is switched to master images and wsgi strategy, 
Added overrides to zuul job run with master images, image overrides
can be dropped once CI defaults changes to master images.

Dropped containerImage reference from README, to use operator defaults

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/4099
Assisted-By: Claude